### PR TITLE
Fix debian typos

### DIFF
--- a/content/docs/engine/usage/cli_usage/images/inspecting_image_content.md
+++ b/content/docs/engine/usage/cli_usage/images/inspecting_image_content.md
@@ -24,7 +24,7 @@ the CONTENT_TYPE can be one of the following types:
 - java: Java Archives
 - python: Python Artifacts
 
-For example: `anchore-cli image content debain:latest files`
+For example: `anchore-cli image content debian:latest files`
 
 The CLI will output a subseet of fields from the content view, for example for `files` on the file name and size are displayed. To retrieve the full output the `--json` parameter should be passed.
 

--- a/content/docs/using/cli_usage/images/inspecting_image_content.md
+++ b/content/docs/using/cli_usage/images/inspecting_image_content.md
@@ -28,7 +28,7 @@ the CONTENT_TYPE can be one of the following types:
 - java: Java Archives
 - python: Python Artifacts
 
-For example: `anchore-cli image content debain:latest files`
+For example: `anchore-cli image content debian:latest files`
 
 The CLI will output a subseet of fields from the content view, for example for `files` on the file name and size are displayed. To retrieve the full output the `--json` parameter should be passed.
 


### PR DESCRIPTION
Fixed a couple places in the documentation where "debian" was misspelled as "debain".

@zhill 