### PR TITLE
use login first, download comes later. Use imperative voice

### DIFF
--- a/content/docs/engine/engine_installation/docker_compose/_index.md
+++ b/content/docs/engine/engine_installation/docker_compose/_index.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to get up and running with a stand-alone Ancho
 
 The following instructions assume you are using a system running Docker v1.12 or higher, and a version of Docker Compose that supports at least v2 of the docker-compose configuration format.
 
-* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.  
+* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.
 
 
 ### Step 1: Setup installation location
@@ -25,7 +25,7 @@ cd ~/aevolume
 
 ### Step 2: Copy configuration files
 
-Download the latest Anchore Engine container image, which contains the necessary `docker-compose.yaml` and configuration files that will be used for the deployment.
+Download the latest Anchore Engine container image, which contains the necessary `docker-compose.yaml` and configuration files that the deployment requires.
 ```
 # docker pull docker.io/anchore/anchore-engine:latest
 ```
@@ -47,8 +47,8 @@ docker-compose.yaml
 
 ### Step 3: Download and run the containers
 
-Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.  
-NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart 
+Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.
+NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart
 
 ```
 # cd ~/aevolume
@@ -63,14 +63,14 @@ After a few moments (depending on system speed), your Anchore Engine services sh
 ```
 # cd ~/aevolume
 # docker-compose ps
-                Name                               Command               State           Ports         
+                Name                               Command               State           Ports
 -------------------------------------------------------------------------------------------------------
-aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp
+aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp
 aevolume_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
-aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
 ```
 
 You can run a command to get the status of the Anchore Engine services:
@@ -93,35 +93,35 @@ Engine Code Version: 0.4.0
 ```
 # cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system feeds list
-Feed                   Group                  LastSync                           RecordCount        
-vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457                
-vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594                
-vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649                
-vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632                
-vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767                
-vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270               
-vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266               
-vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657                
-vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494              
-vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455              
-vulnerabilities        debian:8               None                               0                  
-vulnerabilities        debian:9               None                               0                  
-vulnerabilities        debian:unstable        None                               0                  
-vulnerabilities        ol:5                   None                               0                  
-vulnerabilities        ol:6                   None                               0                  
-vulnerabilities        ol:7                   None                               0                  
-vulnerabilities        ubuntu:12.04           None                               0                  
-vulnerabilities        ubuntu:12.10           None                               0                  
-vulnerabilities        ubuntu:13.04           None                               0                  
-vulnerabilities        ubuntu:14.04           None                               0                  
-vulnerabilities        ubuntu:14.10           None                               0                  
-vulnerabilities        ubuntu:15.04           None                               0                  
-vulnerabilities        ubuntu:15.10           None                               0                  
-vulnerabilities        ubuntu:16.04           None                               0                  
-vulnerabilities        ubuntu:16.10           None                               0                  
-vulnerabilities        ubuntu:17.04           None                               0                  
-vulnerabilities        ubuntu:17.10           None                               0                  
-vulnerabilities        ubuntu:18.04           None                               0                  
+Feed                   Group                  LastSync                           RecordCount
+vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457
+vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594
+vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649
+vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632
+vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767
+vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270
+vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266
+vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657
+vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494
+vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455
+vulnerabilities        debian:8               None                               0
+vulnerabilities        debian:9               None                               0
+vulnerabilities        debian:unstable        None                               0
+vulnerabilities        ol:5                   None                               0
+vulnerabilities        ol:6                   None                               0
+vulnerabilities        ol:7                   None                               0
+vulnerabilities        ubuntu:12.04           None                               0
+vulnerabilities        ubuntu:12.10           None                               0
+vulnerabilities        ubuntu:13.04           None                               0
+vulnerabilities        ubuntu:14.04           None                               0
+vulnerabilities        ubuntu:14.10           None                               0
+vulnerabilities        ubuntu:15.04           None                               0
+vulnerabilities        ubuntu:15.10           None                               0
+vulnerabilities        ubuntu:16.04           None                               0
+vulnerabilities        ubuntu:16.10           None                               0
+vulnerabilities        ubuntu:17.04           None                               0
+vulnerabilities        ubuntu:17.10           None                               0
+vulnerabilities        ubuntu:18.04           None                               0
 ```
 
 As soon as you see RecordCount values > 0 for all vulnerability groups, the system is fully populated and ready to present vulnerability results.   Note that feed syncs are incremental, so the next time you start up Anchore Engine it will be ready immediately.  The CLI tool includes a useful utility that will block until the feeds have completed a successful sync:
@@ -167,11 +167,11 @@ debconf                       1.5.49                       BSD-2-clause
 ...
 
 # docker-compose exec engine-api anchore-cli image vuln docker.io/library/debian:7 all
-Vulnerability ID        Package                                  Severity          Fix         Vulnerability URL                                                 
-CVE-2005-2541           tar-1.26+dfsg-0.1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2005-2541         
-CVE-2007-5686           login-1:4.1.5.1-1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686         
-CVE-2007-5686           passwd-1:4.1.5.1-1+deb7u1                Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686         
-CVE-2007-6755           libssl1.0.0-1.0.1t-1+deb7u4              Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-6755         
+Vulnerability ID        Package                                  Severity          Fix         Vulnerability URL
+CVE-2005-2541           tar-1.26+dfsg-0.1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2005-2541
+CVE-2007-5686           login-1:4.1.5.1-1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686
+CVE-2007-5686           passwd-1:4.1.5.1-1+deb7u1                Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686
+CVE-2007-6755           libssl1.0.0-1.0.1t-1+deb7u4              Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-6755
 ...
 ...
 ...
@@ -184,7 +184,7 @@ Last Eval: 2018-11-06T22:51:47Z
 Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
 ```
 
-**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore to explore the scanning, policy evaluation, image content reporting, CI/CD integrations and other capabilities, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/engine/general" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage. 
+**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore to explore the scanning, policy evaluation, image content reporting, CI/CD integrations and other capabilities, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/engine/general" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage.
 
 ### Next Steps
 

--- a/content/docs/engine/quickstart/_index.md
+++ b/content/docs/engine/quickstart/_index.md
@@ -12,7 +12,7 @@ In this section, you'll learn how to get up and running with a stand-alone Ancho
 
 The following instructions assume you are using a system running Docker v1.12 or higher, and a version of Docker Compose that supports at least v2 of the docker-compose configuration format.
 
-* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.  
+* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.
 
 
 ### Step 1: Setup installation location
@@ -25,7 +25,7 @@ cd ~/aevolume
 
 ### Step 2: Copy configuration files
 
-Download the latest Anchore Engine container image, which contains the necessary `docker-compose.yaml` and configuration files that will be used for the deployment.
+Download the latest Anchore Engine container image, which contains the necessary `docker-compose.yaml` and configuration files that the deployment requires.
 ```
 # docker pull docker.io/anchore/anchore-engine:latest
 ```
@@ -49,8 +49,8 @@ Once these steps are complete, your ~/aevolume/ workspace should now look like t
 
 ### Step 3: Download and run the containers
 
-Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.  
-NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart 
+Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.
+NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart
 
 ```
 # cd ~/aevolume
@@ -65,14 +65,14 @@ After a few moments (depending on system speed), your Anchore Engine services sh
 ```
 # cd ~/aevolume
 # docker-compose ps
-                Name                               Command               State           Ports         
+                Name                               Command               State           Ports
 -------------------------------------------------------------------------------------------------------
-aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp
+aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp
 aevolume_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
-aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
 ```
 
 You can run a command to get the status of the Anchore Engine services:
@@ -95,35 +95,35 @@ Engine Code Version: 0.4.0
 ```
 # cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system feeds list
-Feed                   Group                  LastSync                           RecordCount        
-vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457                
-vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594                
-vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649                
-vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632                
-vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767                
-vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270               
-vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266               
-vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657                
-vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494              
-vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455              
-vulnerabilities        debian:8               None                               0                  
-vulnerabilities        debian:9               None                               0                  
-vulnerabilities        debian:unstable        None                               0                  
-vulnerabilities        ol:5                   None                               0                  
-vulnerabilities        ol:6                   None                               0                  
-vulnerabilities        ol:7                   None                               0                  
-vulnerabilities        ubuntu:12.04           None                               0                  
-vulnerabilities        ubuntu:12.10           None                               0                  
-vulnerabilities        ubuntu:13.04           None                               0                  
-vulnerabilities        ubuntu:14.04           None                               0                  
-vulnerabilities        ubuntu:14.10           None                               0                  
-vulnerabilities        ubuntu:15.04           None                               0                  
-vulnerabilities        ubuntu:15.10           None                               0                  
-vulnerabilities        ubuntu:16.04           None                               0                  
-vulnerabilities        ubuntu:16.10           None                               0                  
-vulnerabilities        ubuntu:17.04           None                               0                  
-vulnerabilities        ubuntu:17.10           None                               0                  
-vulnerabilities        ubuntu:18.04           None                               0                  
+Feed                   Group                  LastSync                           RecordCount
+vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457
+vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594
+vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649
+vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632
+vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767
+vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270
+vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266
+vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657
+vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494
+vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455
+vulnerabilities        debian:8               None                               0
+vulnerabilities        debian:9               None                               0
+vulnerabilities        debian:unstable        None                               0
+vulnerabilities        ol:5                   None                               0
+vulnerabilities        ol:6                   None                               0
+vulnerabilities        ol:7                   None                               0
+vulnerabilities        ubuntu:12.04           None                               0
+vulnerabilities        ubuntu:12.10           None                               0
+vulnerabilities        ubuntu:13.04           None                               0
+vulnerabilities        ubuntu:14.04           None                               0
+vulnerabilities        ubuntu:14.10           None                               0
+vulnerabilities        ubuntu:15.04           None                               0
+vulnerabilities        ubuntu:15.10           None                               0
+vulnerabilities        ubuntu:16.04           None                               0
+vulnerabilities        ubuntu:16.10           None                               0
+vulnerabilities        ubuntu:17.04           None                               0
+vulnerabilities        ubuntu:17.10           None                               0
+vulnerabilities        ubuntu:18.04           None                               0
 ```
 
 As soon as you see RecordCount values > 0 for all vulnerability groups, the system is fully populated and ready to present vulnerability results.   Note that feed syncs are incremental, so the next time you start up Anchore Engine it will be ready immediately.  The CLI tool includes a useful utility that will block until the feeds have completed a successful sync:
@@ -169,11 +169,11 @@ debconf                       1.5.49                       BSD-2-clause
 ...
 
 # docker-compose exec engine-api anchore-cli image vuln docker.io/library/debian:7 all
-Vulnerability ID        Package                                  Severity          Fix         Vulnerability URL                                                 
-CVE-2005-2541           tar-1.26+dfsg-0.1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2005-2541         
-CVE-2007-5686           login-1:4.1.5.1-1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686         
-CVE-2007-5686           passwd-1:4.1.5.1-1+deb7u1                Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686         
-CVE-2007-6755           libssl1.0.0-1.0.1t-1+deb7u4              Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-6755         
+Vulnerability ID        Package                                  Severity          Fix         Vulnerability URL
+CVE-2005-2541           tar-1.26+dfsg-0.1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2005-2541
+CVE-2007-5686           login-1:4.1.5.1-1+deb7u1                 Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686
+CVE-2007-5686           passwd-1:4.1.5.1-1+deb7u1                Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-5686
+CVE-2007-6755           libssl1.0.0-1.0.1t-1+deb7u4              Negligible        None        https://security-tracker.debian.org/tracker/CVE-2007-6755
 ...
 ...
 ...
@@ -186,7 +186,7 @@ Last Eval: 2018-11-06T22:51:47Z
 Policy ID: 2c53a13c-1765-11e8-82ef-23527761d060
 ```
 
-**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore to explore the scanning, policy evaluation, image content reporting, CI/CD integrations and other capabilities, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/engine/general" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage. 
+**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore to explore the scanning, policy evaluation, image content reporting, CI/CD integrations and other capabilities, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/engine/general" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage.
 
 ### Next Steps
 

--- a/content/docs/installation/docker_compose/_index.md
+++ b/content/docs/installation/docker_compose/_index.md
@@ -6,13 +6,13 @@ weight: 2
 
 ## Introduction
 
-In this section, you'll learn how to get up and running with a stand-alone Anchore Enterprise installation for trial, demonstration and review with [Docker Compose](https://docs.docker.com/compose/install/).  
+In this section, you'll learn how to get up and running with a stand-alone Anchore Enterprise installation for trial, demonstration and review with [Docker Compose](https://docs.docker.com/compose/install/).
 
 ## Requirements
 
 The following instructions assume you are using a system running Docker v1.12 or higher, and a version of Docker Compose that supports at least v2 of the docker-compose configuration format.
 
-* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.  
+* A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.
 * In order to access the Anchore Enterprise, you will also require a valid `license.yaml` file that has been issued to you by Anchore.  If you do not have a license yet, visit this page for instructions on how to request one.
 
 
@@ -25,7 +25,7 @@ mkdir ~/aevolume
 
 ### Step 2: Copy configuration files
 
-Download the latest Anchore Enterprise container image, which contains the necessary `docker-compose.yaml` and configuration files that will be used for the deployment.   In order to be able to download the container, you'll need to login to docker (if you are not logged in already) using the dockerhub account that you provided to Anchore when you requested your license.
+Login to docker (if you haven't already) to be able to download the container. Use the dockerhub account you provided to Anchore when you requested your license. The latest Anchore Enterprise container image contains the necessary `docker-compose.yaml` and configuration files that the deployment requires.
 
 ```
 # docker login
@@ -60,8 +60,8 @@ license.yaml
 
 ### Step 3: Download and run the containers
 
-Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.  
-NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart 
+Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.
+NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart
 
 ```
 # cd ~/aevolume
@@ -76,19 +76,19 @@ After a few moments (depending on system speed), your Anchore Engine, Anchore En
 ```
 # cd ~/aevolume
 # docker-compose ps
-                Name                               Command               State           Ports         
+                Name                               Command               State           Ports
 -------------------------------------------------------------------------------------------------------
-aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_anchore-gems-db_1              docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp
+aevolume_anchore-gems-db_1              docker-entrypoint.sh postgres    Up      5432/tcp
+aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp
 aevolume_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
-aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
+aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp
+aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
 aevolume_enterprise-feeds_1             /docker-entrypoint.sh anch ...   Up      0.0.0.0:8448->8228/tcp
-aevolume_enterprise-rbac-authorizer_1   /docker-entrypoint.sh anch ...   Up      8089/tcp, 8228/tcp    
+aevolume_enterprise-rbac-authorizer_1   /docker-entrypoint.sh anch ...   Up      8089/tcp, 8228/tcp
 aevolume_enterprise-rbac-manager_1      /docker-entrypoint.sh anch ...   Up      0.0.0.0:8229->8228/tcp
-aevolume_enterprise-ui-redis_1          docker-entrypoint.sh redis ...   Up      6379/tcp              
+aevolume_enterprise-ui-redis_1          docker-entrypoint.sh redis ...   Up      6379/tcp
 aevolume_enterprise-ui_1                /bin/sh -c node /home/node ...   Up      0.0.0.0:3000->3000/tcp
 ```
 
@@ -116,46 +116,46 @@ Engine Code Version: 0.3.0-dev
 ```
 # cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system feeds list
-Feed                   Group                  LastSync                           RecordCount        
-vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457                
-vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594                
-vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649                
-vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632                
-vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767                
-vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270               
-vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266               
-vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657                
-vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494              
-vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455              
-vulnerabilities        debian:8               None                               0                  
-vulnerabilities        debian:9               None                               0                  
-vulnerabilities        debian:unstable        None                               0                  
-vulnerabilities        ol:5                   None                               0                  
-vulnerabilities        ol:6                   None                               0                  
-vulnerabilities        ol:7                   None                               0                  
-vulnerabilities        ubuntu:12.04           None                               0                  
-vulnerabilities        ubuntu:12.10           None                               0                  
-vulnerabilities        ubuntu:13.04           None                               0                  
-vulnerabilities        ubuntu:14.04           None                               0                  
-vulnerabilities        ubuntu:14.10           None                               0                  
-vulnerabilities        ubuntu:15.04           None                               0                  
-vulnerabilities        ubuntu:15.10           None                               0                  
-vulnerabilities        ubuntu:16.04           None                               0                  
-vulnerabilities        ubuntu:16.10           None                               0                  
-vulnerabilities        ubuntu:17.04           None                               0                  
-vulnerabilities        ubuntu:17.10           None                               0                  
-vulnerabilities        ubuntu:18.04           None                               0                  
+Feed                   Group                  LastSync                           RecordCount
+vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457
+vulnerabilities        alpine:3.4             2018-06-27T17:13:59.103245Z        594
+vulnerabilities        alpine:3.5             2018-06-27T17:14:05.000942Z        649
+vulnerabilities        alpine:3.6             2018-06-27T17:14:10.606606Z        632
+vulnerabilities        alpine:3.7             2018-06-27T17:14:17.673851Z        767
+vulnerabilities        centos:5               2018-06-27T17:14:46.616051Z        1270
+vulnerabilities        centos:6               2018-06-27T17:15:18.600668Z        1266
+vulnerabilities        centos:7               2018-06-27T17:15:41.468527Z        657
+vulnerabilities        debian:10              2018-06-27T17:18:16.960078Z        17494
+vulnerabilities        debian:7               2018-06-27T17:21:20.058941Z        20455
+vulnerabilities        debian:8               None                               0
+vulnerabilities        debian:9               None                               0
+vulnerabilities        debian:unstable        None                               0
+vulnerabilities        ol:5                   None                               0
+vulnerabilities        ol:6                   None                               0
+vulnerabilities        ol:7                   None                               0
+vulnerabilities        ubuntu:12.04           None                               0
+vulnerabilities        ubuntu:12.10           None                               0
+vulnerabilities        ubuntu:13.04           None                               0
+vulnerabilities        ubuntu:14.04           None                               0
+vulnerabilities        ubuntu:14.10           None                               0
+vulnerabilities        ubuntu:15.04           None                               0
+vulnerabilities        ubuntu:15.10           None                               0
+vulnerabilities        ubuntu:16.04           None                               0
+vulnerabilities        ubuntu:16.10           None                               0
+vulnerabilities        ubuntu:17.04           None                               0
+vulnerabilities        ubuntu:17.10           None                               0
+vulnerabilities        ubuntu:18.04           None                               0
 ```
 
 As soon as you see RecordCount values > 0 for all vulnerability groups, the system is fully populated and ready to present vulnerability results.   Note that feed syncs are incremental, so the next time you start up Anchore Enterprise it will be ready immediately.
 
 ### Step 5: Begin using Anchore
 
-You can point your browser at the Anchore Enterprise UI by directing it to _http://localhost:3000/_.  
+You can point your browser at the Anchore Enterprise UI by directing it to _http://localhost:3000/_.
 
 Enter the username _admin_ and password _foobar_ to log in.  There, you will be able to navigate your images, inspect image contents, perform security scans, review compliance policy evaluations, edit compliance policies with a complete policy editor UI, manage accounts/users/RBAC assignments, and review system events (and other UI features).
 
-**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore Enterprise, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/overview" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage. 
+**Note:** This document is intended to serve as a quickstart guide. Before moving further with Anchore Enterprise, it is highly recommended that you enhance your learning by reading the [Overview]({{< ref "/docs/overview" >}}) sections to gain a deeper understanding of fundamentals, concepts, and proper usage.
 
 ### Next Steps
 


### PR DESCRIPTION
Seems like my editor went crazy with the trailing space... I can go and undo that if we don't want that type of changes.

Going through https://docs.anchore.com/current/docs/quickstart/, in step 2 (Copy configuration files) it was odd to try and follow the direction to _"Download the latest Anchore Engine"_ before understanding that one needs to be logged in with the right credentials. So I swapped it around and used imperative voice.