### PR TITLE
Adds docker-compose.yaml for engine and enterprise 

### DIFF
--- a/content/docs/engine/quickstart/_index.md
+++ b/content/docs/engine/quickstart/_index.md
@@ -8,6 +8,8 @@ weight: 1
 
 In this section, you'll learn how to get up and running with a stand-alone Anchore Engine installation for trial, demonstration and review with [Docker Compose](https://docs.docker.com/compose/install/).
 
+The quickstart docker-compose.yaml file is available [here](./docker-compose.yaml)
+
 ## Requirements
 
 The following instructions assume you are using a system running Docker v1.12 or higher, and a version of Docker Compose that supports at least v2 of the docker-compose configuration format.
@@ -15,70 +17,32 @@ The following instructions assume you are using a system running Docker v1.12 or
 * A stand-alone installation will requires at least 4GB of RAM, and enough disk space available to support the largest container images you intend to analyze (we recommend 3x largest container image size).  For small images/testing (basic Linux distro images, database images, etc), between 5GB and 10GB of disk space should be sufficient.
 
 
-### Step 1: Setup installation location
-
-Create a directory in which to store your configuration files.
-```
-mkdir ~/aevolume
-cd ~/aevolume
-```
-
-### Step 2: Copy configuration files
-
-Download the latest Anchore Engine container image, which contains the necessary `docker-compose.yaml` and configuration files that the deployment requires.
-```
-# docker pull docker.io/anchore/anchore-engine:latest
-```
-
-Next, copy the included docker-compose.yaml to the ~/aevolume/ directory.
+### Step 1: Download the docker-compose.yaml file and start.
 
 ```
-# docker create --name ae docker.io/anchore/anchore-engine:latest
-# docker cp ae:/docker-compose.yaml ~/aevolume/docker-compose.yaml
-# docker rm ae
-```
-
-Once these steps are complete, your ~/aevolume/ workspace should now look like this:
-
-```
-# cd ~/aevolume
-# find .
-.
-./docker-compose.yaml
-```
-
-### Step 3: Download and run the containers
-
-Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.
-NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart
-
-```
-# cd ~/aevolume
-# docker-compose pull
+# curl https://docs.anchore.com/current/docs/engine/quickstart/docker-compose.yaml > docker-compose.yaml
 # docker-compose up -d
 ```
 
-### Step 4: Verify service availability
+### Step 2: Verify service availability
 
 After a few moments (depending on system speed), your Anchore Engine services should be up and running, ready to use.  You can verify the containers are running with docker-compose:
 
 ```
-# cd ~/aevolume
 # docker-compose ps
-                Name                               Command               State           Ports
+                Name                               Command                        State           Ports
 -------------------------------------------------------------------------------------------------------
-aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp
-aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp
-aevolume_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
-aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
-aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp
-aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
+anchorequickstart_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp
+anchorequickstart_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp
+anchorequickstart_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
+anchorequickstart_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
+anchorequickstart_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp
+anchorequickstart_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp
 ```
 
 You can run a command to get the status of the Anchore Engine services:
 
 ```
-# cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system status
 Service policy_engine (anchore-quickstart, http://engine-policy-engine:8228): up
 Service simplequeue (anchore-quickstart, http://engine-simpleq:8228): up
@@ -93,7 +57,6 @@ Engine Code Version: 0.4.0
 **Note:** The first time you run Anchore Engine, it will take some time (10+ minutes, depending on network speed) for the vulnerability data to get synced into the engine.  For the best experience, wait until the core vulnerability data feeds have completed before proceeding.  You can check the status of your feed sync using the CLI:
 
 ```
-# cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system feeds list
 Feed                   Group                  LastSync                           RecordCount
 vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457
@@ -143,7 +106,7 @@ Feed sync: Success.
 
 ```
 
-### Step 5: Begin using Anchore
+### Step 3: Begin using Anchore
 
 Start using the anchore-engine service to analyze images - a short example follows which demonstrates a basic workflow of adding a container image for analysis, waiting for the analysis to complete, then running content reports, vulnerability scans and policy evaluations against the analyzed image.
 

--- a/content/docs/engine/quickstart/docker-compose.yaml
+++ b/content/docs/engine/quickstart/docker-compose.yaml
@@ -1,0 +1,158 @@
+---
+version: '2.1'
+volumes:
+  anchore-db-volume:
+    # Set this to 'true' to use an external volume. In which case, it must be created manually with "docker volume create anchore-db-volume"
+    external: false
+
+  anchore-scratch: {}
+
+services:
+  # The primary API endpoint service
+  engine-api:
+    image: anchore/anchore-engine:v0.7.1
+    depends_on:
+    - anchore-db
+    - engine-catalog
+    #volumes:
+    #- ./config-engine.yaml:/config/config.yaml:z
+    ports:
+    - "8228:8228"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=engine-api
+    - ANCHORE_DB_HOST=anchore-db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_LOG_LEVEL=INFO
+    command: ["anchore-manager", "service", "start", "apiext"]
+
+  # Catalog is the primary persistence and state manager of the system
+  engine-catalog:
+    image: anchore/anchore-engine:v0.7.1
+    depends_on:
+    - anchore-db
+    #volumes:
+    #- ./config-engine.yaml:/config/config.yaml:z
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    expose:
+    - 8228
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=engine-catalog
+    - ANCHORE_DB_HOST=anchore-db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_LOG_LEVEL=INFO
+    command: ["anchore-manager", "service", "start", "catalog"]
+  engine-simpleq:
+    image: anchore/anchore-engine:v0.7.1
+    depends_on:
+    - anchore-db
+    - engine-catalog
+    #volumes:
+    #- ./config-engine.yaml:/config/config.yaml:z
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=engine-simpleq
+    - ANCHORE_DB_HOST=anchore-db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_LOG_LEVEL=INFO
+    command: ["anchore-manager", "service", "start", "simplequeue"]
+  engine-policy-engine:
+    image: anchore/anchore-engine:v0.7.1
+    depends_on:
+    - anchore-db
+    - engine-catalog
+    #volumes:
+    #- ./config-engine.yaml:/config/config.yaml:z
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=engine-policy-engine
+    - ANCHORE_DB_HOST=anchore-db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_LOG_LEVEL=INFO
+    command: ["anchore-manager", "service", "start", "policy_engine"]
+  engine-analyzer:
+    image: anchore/anchore-engine:v0.7.1
+    depends_on:
+    - anchore-db
+    - engine-catalog
+    #volumes:
+    #- ./config-engine.yaml:/config/config.yaml:z
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=engine-analyzer
+    - ANCHORE_DB_HOST=anchore-db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_LOG_LEVEL=INFO
+    volumes:
+    - anchore-scratch:/analysis_scratch
+    command: ["anchore-manager", "service", "start", "analyzer"]
+  anchore-db:
+    image: "anchore/engine-db-preload:v0.7.1"
+    volumes:
+    - anchore-db-volume:/var/lib/postgresql/data
+    environment:
+    - POSTGRES_PASSWORD=mysecretpassword
+    expose:
+    - 5432
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+
+# Uncomment this section to add a prometheus instance to gather metrics. This is mostly for quickstart to demonstrate prometheus metrics exported
+#  anchore-prometheus:
+#      image: docker.io/prom/prometheus:latest
+#      depends_on:
+#       - engine-api
+#      volumes:
+#       - ./anchore-prometheus.yml:/etc/prometheus/prometheus.yml:z
+#      logging:
+#       driver: "json-file"
+#       options:
+#        max-size: 100m
+#      ports:
+#       - "9090:9090"
+
+# Uncomment this section to run a swagger UI service, for inspecting and interacting with the anchore engine API via a browser (http://localhost:8080 by default, change if needed in both sections below)
+#  anchore-swagger-ui-nginx:
+#    image: docker.io/nginx:latest
+#    depends_on:
+#     - engine-api
+#     - anchore-swagger-ui
+#    ports:
+#     - "8080:8080"
+#    volumes:
+#     - ./anchore-swaggerui-nginx.conf:/etc/nginx/nginx.conf:z
+#    logging:
+#     driver: "json-file"
+#     options:
+#      max-size: 100m
+#  anchore-swagger-ui:
+#    image: docker.io/swaggerapi/swagger-ui
+#    environment:
+#      - URL=http://localhost:8080/v1/swagger.json
+#    logging:
+#     driver: "json-file"
+#     options:
+#      max-size: 100m

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -22,7 +22,7 @@ The following instructions assume you are using a system running Docker v1.12 or
 
 ### Step 1: Ensure you can authenticate to DockerHub to pull the images
 
-You'll need authenticated access to the `anchore/enterprise` and `anchore/enterprise-ui` repositories on DockerHub. Anchore support should have granted your DockerHub user access when you recewived your license.
+You'll need authenticated access to the `anchore/enterprise` and `anchore/enterprise-ui` repositories on DockerHub. Anchore support should have granted your DockerHub user access when you received your license.
 
 ```
 # docker login

--- a/content/docs/quickstart/_index.md
+++ b/content/docs/quickstart/_index.md
@@ -8,6 +8,8 @@ weight: 1
 
 In this section, you'll learn how to get up and running with a stand-alone Anchore Enterprise installation for trial, demonstration, and review with [Docker Compose](https://docs.docker.com/compose/install/). If you are specifically looking for a quickstart for Anchore Engine OSS alone, please jump to [Anchore Engine Quickstart]({{< ref "/docs/engine/quickstart" >}}).
 
+The quickstart docker-compose.yaml file is available [here](./docker-compose.yaml)
+
 **Note:** If your intent is to gain a deeper understanding of Anchore and its concepts, we recommend navigating to the [Overview]({{< ref "/docs/overview" >}}) section prior to conducting an [installation]({{< ref "/docs/installation" >}}) of Anchore Enterprise.
 
 ## Requirements
@@ -18,80 +20,46 @@ The following instructions assume you are using a system running Docker v1.12 or
 * In order to access the Anchore Enterprise, you will also require a valid `license.yaml` file that has been issued to you by Anchore.  If you do not have a license yet, visit this [page](https://info.anchore.com/contact) for instructions on how to request one.
 
 
-### Step 1: Setup installation location
+### Step 1: Ensure you can authenticate to DockerHub to pull the images
 
-Create a directory in which to store your configuration files and license file.
-```
-mkdir ~/aevolume
-```
-
-### Step 2: Copy configuration files
-
-Download the latest Anchore Enterprise container image, which contains the necessary `docker-compose.yaml` and configuration files that will be used for the deployment.   In order to be able to download the container, you'll need to login to docker (if you are not logged in already) using the dockerhub account that you provided to Anchore when you requested your license.
+You'll need authenticated access to the `anchore/enterprise` and `anchore/enterprise-ui` repositories on DockerHub. Anchore support should have granted your DockerHub user access when you recewived your license.
 
 ```
 # docker login
 Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.
 Username: <your_dockerhub_account>
 Password: <your_dockerhub_password>
-
-# docker pull docker.io/anchore/enterprise:latest
 ```
 
-Next, copy the included docker-compose.yaml to the ~/aevolume/ directory.
+### Step 2: Download compose, copy license and start.
 
+ Now, ensure the license.yaml file you got from Anchore Sales/Support is in the directory where you want to run the containers from, then download the compose file and start it.
 ```
-# docker create --name ae docker.io/anchore/enterprise:latest
-# docker cp ae:/docker-compose.yaml ~/aevolume/docker-compose.yaml
-# docker rm ae
-```
-
-Finally, copy the license.yaml file that was provided to you into the ~/aevolume/ directory.
-
-```
-# cp /path/to/your/license.yaml ~/aevolume/license.yaml
-```
-
-Once these steps are complete, your ~/aevolume/ workspace should now look like this:
-
-```
-# ls ~/aevolume
-docker-compose.yaml
-license.yaml
-```
-
-### Step 3: Download and run the containers
-
-Download the containers listed in the `docker-compose.yaml`, and run the entire setup using the docker-compose CLI.  
-NOTE: by default, all services (including a bundled DB instance) will be transient, and data will be lost if you shut down/restart 
-
-```
-# cd ~/aevolume
-# docker-compose pull
+# cp <path/to/your/license.yaml> ./license.yaml
+# curl https://docs.anchore.com/current/docs/quickstart/docker-compose.yaml > docker-compose.yaml
 # docker-compose up -d
 ```
 
-### Step 4: Verify service availability
+### Step 3: Verify service availability
 
 After a few moments (depending on system speed), your Anchore Engine, Anchore Enterprise, and Anchore UI services should be up and running, ready to use.  You can verify the containers are running with docker-compose:
 
 ```
-# cd ~/aevolume
 # docker-compose ps
-                Name                               Command               State           Ports         
+                Name                               Command                        State           Ports         
 -------------------------------------------------------------------------------------------------------
-aevolume_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_anchore-gems-db_1              docker-entrypoint.sh postgres    Up      5432/tcp              
-aevolume_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
-aevolume_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
-aevolume_enterprise-feeds_1             /docker-entrypoint.sh anch ...   Up      0.0.0.0:8448->8228/tcp
-aevolume_enterprise-rbac-authorizer_1   /docker-entrypoint.sh anch ...   Up      8089/tcp, 8228/tcp    
-aevolume_enterprise-rbac-manager_1      /docker-entrypoint.sh anch ...   Up      0.0.0.0:8229->8228/tcp
-aevolume_enterprise-ui-redis_1          docker-entrypoint.sh redis ...   Up      6379/tcp              
-aevolume_enterprise-ui_1                /bin/sh -c node /home/node ...   Up      0.0.0.0:3000->3000/tcp
+anchorequickstart_anchore-db_1                   docker-entrypoint.sh postgres    Up      5432/tcp              
+anchorequickstart_anchore-gems-db_1              docker-entrypoint.sh postgres    Up      5432/tcp              
+anchorequickstart_engine-analyzer_1              /docker-entrypoint.sh anch ...   Up      8228/tcp              
+anchorequickstart_engine-api_1                   /docker-entrypoint.sh anch ...   Up      0.0.0.0:8228->8228/tcp
+anchorequickstart_engine-catalog_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
+anchorequickstart_engine-policy-engine_1         /docker-entrypoint.sh anch ...   Up      8228/tcp              
+anchorequickstart_engine-simpleq_1               /docker-entrypoint.sh anch ...   Up      8228/tcp              
+anchorequickstart_enterprise-feeds_1             /docker-entrypoint.sh anch ...   Up      0.0.0.0:8448->8228/tcp
+anchorequickstart_enterprise-rbac-authorizer_1   /docker-entrypoint.sh anch ...   Up      8089/tcp, 8228/tcp    
+anchorequickstart_enterprise-rbac-manager_1      /docker-entrypoint.sh anch ...   Up      0.0.0.0:8229->8228/tcp
+anchorequickstart_enterprise-ui-redis_1          docker-entrypoint.sh redis ...   Up      6379/tcp              
+anchorequickstart_enterprise-ui_1                /bin/sh -c node /home/node ...   Up      0.0.0.0:3000->3000/tcp
 ```
 
 You can run a command to get the status of the Anchore Engine services:
@@ -99,7 +67,6 @@ You can run a command to get the status of the Anchore Engine services:
 
 
 ```
-# cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system status
 Service policy_engine (anchore-quickstart, http://engine-policy-engine:8228): up
 Service rbac_authorizer (anchore-quickstart, http://enterprise-rbac-authorizer:8228): up
@@ -116,7 +83,6 @@ Engine Code Version: 0.3.0-dev
 **Note:** The first time you run Anchore Enterprise, it will take some time (10+ minutes, depending on network speed) for the vulnerability data to get synced into the engine.  For the best experience, wait until the core vulnerability data feeds have completed before proceeding.  You can check the status of your feed sync using the CLI:
 
 ```
-# cd ~/aevolume
 # docker-compose exec engine-api anchore-cli system feeds list
 Feed                   Group                  LastSync                           RecordCount        
 vulnerabilities        alpine:3.3             2018-06-27T17:13:53.509309Z        457                
@@ -151,12 +117,11 @@ vulnerabilities        ubuntu:18.04           None                              
 
 As soon as you see RecordCount values > 0 for all vulnerability groups, the system is fully populated and ready to present vulnerability results.   Note that feed syncs are incremental, so the next time you start up Anchore Enterprise it will be ready immediately.
 
-### Step 5: Start using Anchore
+### Step 4: Start using Anchore
 
 To get started, you can add a few images to Anchore Engine using the CLI. Once this is done, you can also run an additional CLI command to monitor the analysis state of the added images, waiting until the images move into an 'analyzed' state.
 
 ```
-# cd ~/aevolume
 # docker-compose exec engine-api anchore-cli image add docker.io/library/alpine:latest
 ...
 ...

--- a/content/docs/quickstart/docker-compose.yaml
+++ b/content/docs/quickstart/docker-compose.yaml
@@ -1,0 +1,370 @@
+# All-in-one docker-compose deployment of a full anchore-enterprise service system
+---
+version: '2.1'
+volumes:
+  anchore-db-volume:
+    # Set this to 'true' to use an external volume. In which case, it must be created manually with "docker volume create anchore-db-volume"
+    external: false
+  anchore-scratch: {}
+  feeds-workspace-volume:
+    # Set this to 'true' to use an external volume. In which case, it must be created manually with "docker volume create feeds-workspace-volume"
+    external: false
+  enterprise-feeds-db-volume:
+    # Set this to 'true' to use an external volume. In which case, it must be created manually with "docker volume create enterprise-feeds-db-volume"
+    external: false
+
+services:
+  # The primary API endpoint service
+  api:
+    image: docker.io/anchore/enterprise:v2.3.0
+    depends_on:
+    - db
+    - catalog
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-engine.yaml:/config/config.yaml:z
+    ports:
+    - "8228:8228"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=api
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_AUTHZ_HANDLER=external
+    - ANCHORE_EXTERNAL_AUTHZ_ENDPOINT=http://rbac-authorizer:8228
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "apiext"]
+  # Catalog is the primary persistence and state manager of the system
+  catalog:
+    image: docker.io/anchore/enterprise:v2.3.0
+    depends_on:
+    - db
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-engine.yaml:/config/config.yaml:z
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    expose:
+    - 8228
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=catalog
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    - ANCHORE_CATALOG_NOTIFICATION_INTERVAL_SEC=0
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "catalog"]
+  simpleq:
+    image: docker.io/anchore/enterprise:v2.3.0
+    depends_on:
+    - db
+    - catalog
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-engine.yaml:/config/config.yaml:z
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=simpleq
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "simplequeue"]
+  policy-engine:
+    image: docker.io/anchore/enterprise:v2.3.0
+    depends_on:
+    - db
+    - catalog
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-engine.yaml:/config/config.yaml:z
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=policy-engine
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment the ANCHORE_FEEDS_* environment variables (and uncomment the feeds db and service sections at the end of this file) to use the on-prem feed service
+    #- ANCHORE_FEEDS_URL=http://feeds:8228/v1/feeds
+    #- ANCHORE_FEEDS_CLIENT_URL=null
+    #- ANCHORE_FEEDS_TOKEN_URL=null
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "policy_engine"]
+  analyzer:
+    image: docker.io/anchore/enterprise:v2.3.0
+    depends_on:
+    - db
+    - catalog
+    expose:
+    - 8228
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=analyzer
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    - anchore-scratch:/analysis_scratch
+    #- ./config-engine.yaml:/config/config.yaml:z
+    command: ["anchore-enterprise-manager", "service", "start",  "analyzer"]
+  db:
+    image: "postgres:9"
+    volumes:
+    - anchore-db-volume:/var/lib/postgresql/data
+    environment:
+    - POSTGRES_PASSWORD=mysecretpassword
+    expose:
+    - 5432
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+  rbac-authorizer:
+    image: docker.io/anchore/enterprise:v2.3.0
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-enterprise.yaml:/config/config.yaml:z
+    depends_on:
+    - db
+    - catalog
+    expose:
+    - 8089
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=rbac-authorizer
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "rbac_authorizer"]
+  rbac-manager:
+    image: docker.io/anchore/enterprise:v2.3.0
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-enterprise.yaml:/config/config.yaml:z
+    depends_on:
+    - db
+    - catalog
+    ports:
+    - "8229:8228"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=rbac-manager
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_AUTHZ_HANDLER=external
+    - ANCHORE_EXTERNAL_AUTHZ_ENDPOINT=http://rbac-authorizer:8228
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "rbac_manager"]
+  reports:
+    image: docker.io/anchore/enterprise:v2.3.0
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    depends_on:
+    - db
+    - catalog
+    ports:
+    - "8558:8228"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=reports
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_AUTHZ_HANDLER=external
+    - ANCHORE_EXTERNAL_AUTHZ_ENDPOINT=http://rbac-authorizer:8228
+    - ANCHORE_LOG_LEVEL=INFO
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "reports"]
+  notifications:
+    image: docker.io/anchore/enterprise:v2.3.0
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    depends_on:
+    - db
+    - catalog
+    ports:
+    - "8668:8228"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENDPOINT_HOSTNAME=notifications
+    - ANCHORE_DB_HOST=db
+    - ANCHORE_DB_PASSWORD=mysecretpassword
+    - ANCHORE_ENABLE_METRICS=false
+    - ANCHORE_AUTHZ_HANDLER=external
+    - ANCHORE_EXTERNAL_AUTHZ_ENDPOINT=http://rbac-authorizer:8228
+    - ANCHORE_LOG_LEVEL=INFO
+    - ANCHORE_ENTERPRISE_UI_URL=http://localhost:3000
+    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+    #- ANCHORE_OAUTH_ENABLED=true
+    #- ANCHORE_AUTH_SECRET=supersharedsecret
+    command: ["anchore-enterprise-manager", "service", "start",  "notifications"]
+  ui-redis:
+    image: "docker.io/library/redis:4"
+    expose:
+    - 6379
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+  ui:
+    image: docker.io/anchore/enterprise-ui:v2.3.0
+    volumes:
+    - ./license.yaml:/license.yaml:ro
+    #- ./config-ui.yaml:/config/config-ui.yaml:z
+    depends_on:
+    - api
+    - ui-redis
+    - db
+    ports:
+    - "3000:3000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 100m
+    environment:
+    - ANCHORE_ENGINE_URI=http://api:8228/v1
+    - ANCHORE_RBAC_URI=http://rbac-manager:8228/v1
+    - ANCHORE_REDIS_URI=redis://ui-redis:6379
+    - ANCHORE_APPDB_URI=postgres://postgres:mysecretpassword@db:5432/postgres
+    - ANCHORE_REPORTS_URI=http://reports:8228/v1
+    - ANCHORE_POLICY_HUB_URI=https://hub.anchore.io
+
+# Uncomment this sectionto add an on-prem feed service to this deployment. This will incur first-time feed sync delay, but is included for completeness / review of enterprise service deployment options
+#  enterprise-feeds-db:
+#    image: "postgres:9"
+#    volumes:
+#    - feeds-db-volume:/var/lib/postgresql/data
+#    environment:
+#    - POSTGRES_PASSWORD=mysecretpassword
+#    expose:
+#    - 5432
+#    logging:
+#      driver: "json-file"
+#      options:
+#        max-size: 100m
+#  feeds:
+#    image: docker.io/anchore/enterprise:v2.3.0
+#    volumes:
+#    - feeds-workspace-volume:/workspace
+#    - ./license.yaml:/license.yaml:ro
+#    #- ./config-enterprise.yaml:/config/config.yaml:z
+#    depends_on:
+#    - feeds-db
+#    ports:
+#    - "8448:8228"
+#    logging:
+#      driver: "json-file"
+#      options:
+#        max-size: 100m
+#    environment:
+#    - ANCHORE_ENDPOINT_HOSTNAME=feeds
+#    - ANCHORE_DB_HOST=feeds-db
+#    - ANCHORE_DB_PASSWORD=mysecretpassword
+#    - ANCHORE_ENABLE_METRICS=false
+#    - ANCHORE_LOG_LEVEL=INFO
+#    # Uncomment the following to enable Microsoft msrc driver. Follow https://portal.msrc.microsoft.com/en-us/developer to generate an API key
+#    #- ANCHORE_ENTERPRISE_FEEDS_MSRC_DRIVER_ENABLED=true
+#    #- ANCHORE_ENTERPRISE_FEEDS_MSRC_DRIVER_API_KEY=api-key
+#    # Uncomment ANCHORE_ENTERPRISE_FEEDS_GITHUB_DRIVER_TOKEN for github driver.
+#    # Generate token with https://github.com/settings/tokens/new?scopes=user,public_repo,repo,repo_deployment,repo:status,read:repo_hook,read:org,read:public_key,read:gpg_key
+#    # and assign the value to environment variable
+#    #- ANCHORE_ENTERPRISE_FEEDS_GITHUB_DRIVER_TOKEN=github_token
+#    # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
+#    #- ANCHORE_OAUTH_ENABLED=true
+#    #- ANCHORE_AUTH_SECRET=supersharedsecret
+#    command: ["anchore-enterprise-manager", "service", "start",  "feeds"]
+
+# Uncomment this sectionto add a prometheus instance to gather metrics. This is mostly for quickstart to demonstrate prometheus metrics exported
+#  prometheus:
+#      image: docker.io/prom/prometheus:latest
+#      depends_on:
+#       - api
+#      volumes:
+#       - ./anchore-prometheus.yml:/etc/prometheus/prometheus.yml:z
+#      logging:
+#       driver: "json-file"
+#       options:
+#        max-size: 100m
+#      ports:
+#       - "9090:9090"
+
+# Uncomment this section to run a swagger UI service, for inspecting and interacting with the anchore engine API via a browser (http://localhost:8080 by default, change if needed in both sections below)
+#  swagger-ui-nginx:
+#    image: docker.io/nginx:latest
+#    depends_on:
+#     - api
+#     - swagger-ui
+#    ports:
+#     - "8080:8080"
+#    volumes:
+#     - ./anchore-swaggerui-nginx.conf:/etc/nginx/nginx.conf:z
+#    logging:
+#     driver: "json-file"
+#     options:
+#      max-size: 100m
+#  swagger-ui:
+#    image: docker.io/swaggerapi/swagger-ui
+#    environment:
+#      - URL=http://localhost:8080/v1/swagger.json
+#    logging:
+#     driver: "json-file"
+#     options:
+#      max-size: 100m


### PR DESCRIPTION
Adds the docker-compose.yaml files to the docs directly so they'll be hosted on the docs site in predictable locations and versioned with the releases. This makes it easier for folks to view/read them without pulling the full image and also simplifies the quickstart flow.

The reason they were bundled into the image was for version control to ensure folks got the right version of the compose for the images on DockerHub and did not get development versions. Now that we have the docs site with versioning this can be accomplished here without requiring images to be rebuilt to update the compose files.