### PR TITLE
add postgres healthcheck to engine compose file

### DIFF
--- a/content/docs/engine/quickstart/docker-compose.yaml
+++ b/content/docs/engine/quickstart/docker-compose.yaml
@@ -105,6 +105,8 @@ services:
       driver: "json-file"
       options:
         max-size: 100m
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
 #  # Uncomment this section to add a prometheus instance to gather metrics. This is mostly for quickstart to demonstrate prometheus metrics exported
 #  anchore-prometheus:
 #    image: docker.io/prom/prometheus:latest


### PR DESCRIPTION
Signed-off-by: Paul V. Novarese <pvn@novarese.net>

postgres doesn't have a healthcheck defined by default (and is the only container in the compose file that doesn't), which leads to unaesthetic output like this:

```
pvn@gyarados /home/pvn/compose/anchore> docker-compose ps
         Name                        Command                  State               Ports
------------------------------------------------------------------------------------------------
anchore_analyzer_1        /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_api_1             /docker-entrypoint.sh anch ...   Up (healthy)   0.0.0.0:8228->8228/tcp
anchore_catalog_1         /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_db_1              docker-entrypoint.sh postgres    Up             5432/tcp
anchore_policy-engine_1   /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_queue_1           /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
```

adding a simple healthcheck using `pg_isready` to get something more pleasing:

```
pvn@gyarados /home/pvn/compose/anchore> docker-compose ps
         Name                        Command                  State               Ports
------------------------------------------------------------------------------------------------
anchore_analyzer_1        /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_api_1             /docker-entrypoint.sh anch ...   Up (healthy)   0.0.0.0:8228->8228/tcp
anchore_catalog_1         /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_db_1              docker-entrypoint.sh postgres    Up (healthy)   5432/tcp
anchore_policy-engine_1   /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
anchore_queue_1           /docker-entrypoint.sh anch ...   Up (healthy)   8228/tcp
```

this is specifically for the engine quickstart compose file, but it could also apply to the enterprise compose file for the anchore-db service (I'm not an enterprise user so I haven't actually tested it).