### PR TITLE
adding redis and postgres healthchecks to enterprise docker-compose file

### DIFF
--- a/content/docs/quickstart/docker-compose.yaml
+++ b/content/docs/quickstart/docker-compose.yaml
@@ -156,6 +156,8 @@ services:
       driver: "json-file"
       options:
         max-size: 100m
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
   rbac-authorizer:
     image: docker.io/anchore/enterprise:v2.3.2
     volumes:
@@ -267,6 +269,8 @@ services:
       driver: "json-file"
       options:
         max-size: 100m
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli PING"]
   ui:
     image: docker.io/anchore/enterprise-ui:v2.3.2
     volumes:


### PR DESCRIPTION
Signed-off-by: Paul V. Novarese pvn@novarese.net

postgres and redis don't have healthchecks defined by default, which leads to displeasing output like this:

```
pvn@gyarados /home/pvn> docker ps
CONTAINER ID        NAMES                                  IMAGE                               CREATED              STATUS
2b762a31b56a        anchore-enterprise_ui_1                anchore/enterprise-ui:v2.3.2        About a minute ago   Up About a minute (healthy)
fa0e6ae8eaa0        anchore-enterprise_queue_1             anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
49cfecfca396        anchore-enterprise_notifications_1     anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
0225b5be2fd6        anchore-enterprise_rbac-authorizer_1   anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
2d3b9471ea38        anchore-enterprise_rbac-manager_1      anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
8acaab67962e        anchore-enterprise_policy-engine_1     anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
05f0486beb7a        anchore-enterprise_analyzer_1          anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
4b2ef9e65bcd        anchore-enterprise_reports_1           anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
89d72e1878e3        anchore-enterprise_api_1               anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
b388eb31beb5        anchore-enterprise_catalog_1           anchore/enterprise:v2.3.2           About a minute ago   Up About a minute (healthy)
580ae9e33984        anchore-enterprise_anchore-db_1        postgres:9                          About a minute ago   Up About a minute
f3decac9c33d        anchore-enterprise_ui-redis_1          redis:4                             About a minute ago   Up About a minute
```

for postgres, I added a simple pg_isready check and for redis, a redis-cli PING

```
pvn@gyarados /home/pvn> docker ps
CONTAINER ID        NAMES                                  IMAGE                               CREATED             STATUS
b9162a1edf26        anchore-enterprise_ui_1                anchore/enterprise-ui:v2.3.2        4 minutes ago       Up 4 minutes (healthy)
3f13d17cafe8        anchore-enterprise_reports_1           anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
5006304c6226        anchore-enterprise_analyzer_1          anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
a799dee3c9b8        anchore-enterprise_policy-engine_1     anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
3aebbbb4382b        anchore-enterprise_rbac-manager_1      anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
917fbe7eb0e5        anchore-enterprise_notifications_1     anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
50afa6e225af        anchore-enterprise_queue_1             anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
b4b74cb9447a        anchore-enterprise_api_1               anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
cbf7b7133386        anchore-enterprise_rbac-authorizer_1   anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
2dd3f8d98162        anchore-enterprise_catalog_1           anchore/enterprise:v2.3.2           4 minutes ago       Up 4 minutes (healthy)
b7080a0ee188        anchore-enterprise_anchore-db_1        postgres:9                          5 minutes ago       Up 4 minutes (healthy)
bef595f33fad        anchore-enterprise_ui-redis_1          redis:4                             5 minutes ago       Up 4 minutes (healthy)
```
