### PR TITLE
Adds Engine 0.8.0 release notes and documentation for features.

### DIFF
--- a/content/docs/engine/engine_installation/configuration/content_hints.md
+++ b/content/docs/engine/engine_installation/configuration/content_hints.md
@@ -1,0 +1,21 @@
+---
+title: "Configuring Content Hints"
+linkTitle: "Configuring Content Hints"
+weight: 5
+---
+
+For an overview of the content hints and overrides features, see the [feature overview]({{<ref "/docs/engine/general/concepts/images/analysis/content_hints" >}})
+
+## Enabling Content Hints
+
+This feature is disabled by default to ensure that images may not exercise this feature without the admin's explicit approval.
+
+In the each analyzer's ```config.yaml``` file (by default at ```/config/config.yaml```):
+
+Set the ```enable_hints: true``` setting in the ```analyzer``` service section of config.yaml.  
+
+If using the default config.yaml included in the image, you may instead set an environment variable (e.g for use in our provided config for Docker Compose for [Quickstart]({{< ref "/docs/engine/quickstart" >}})):
+
+```ANCHORE_HINTS_ENABLED=true``` environment variable for the analyzer service.
+
+For Helm: see the Helm installation instructions for enabling the hints file mechanism when deploying with Helm.

--- a/content/docs/engine/engine_installation/configuration/malware.md
+++ b/content/docs/engine/engine_installation/configuration/malware.md
@@ -1,0 +1,46 @@
+---
+title: "Configuring Malware Scans of Images"
+linkTitle: "Confinguring Malware Scanning"
+weight: 8
+---
+
+## Malware Scanning Overview
+
+See [Malware Scanning]({{< ref "/docs/engine/general/concepts/images/analysis/malware_scanning" >}}) for an overview of the feature and how it works. This section is for configuration of scan behavior.
+
+Customizing the `analyzer_config.yaml` requires a restart of the analyzer container. The typical process is to mount it externally into `/config/analyzer_config.yaml` from a host volume or as a ConfigMap in Kubernetes and
+all analyzers in the deployment share the same configuration.
+
+## Enabling & Disabling Malware Scans
+
+Each analyzer needs to have it's analyzer_config.yaml file updated to include:
+```
+malware:
+  clamav:
+    enabled: true
+    db_update_enabled: true
+```
+
+malware.clamav.enabled = true will enable the analyzer that runs the scan. If not enabled, the analyzer will run but will not execute a ClamAV scan so no scan results
+will be reported.
+
+## Disabling DB Updates for ClamAV
+
+The `db_update_enabled` property of the malware.clamav object shown above in the analyzer_config.yaml controls whether the analyzer will invoke a `refreshclam` call prior to each
+analysis execution. By default it is enabled and should be left on for up-to-date scan results. The db version is returned in the metadata section of the scan results available from the engine API.
+
+You can disable the update if you want to mount an external volume to provide the db data in _/home/anchore/clamav/db_ inside the container (must be read-write for the anchore user) This can be used
+to cache or share a db across multiple analyzers (e.g. using AWS EFS) or to support air-gapped deployments where the db cannot be automatically updated from deployment itself.
+
+## Advanced Configuration
+
+The path for the db and db update configuration are also available as environment variables inside the analyzer containers. These should not need to be used in most cases, but 
+for airgapped or other installation where the default configuration is not sufficient they are available for customization.
+
+| Name                             | Description                               | Default |
+|----------------------------------|-------------------------------------------|---------|
+| ANCHORE_FRESHCLAM_CONFIG_FILE    | Location of freshclam.conf to use         | /home/anchore/clamav/freshclam.conf |
+| ANCHORE_CLAMAV_DB_DIR            | Location of the db dir to read/write      | /home/anchore/clamav/db |
+
+
+The invocation parameters for each command are available in the [analyzer source](https://github.com/anchore/anchore-engine/blob/master/anchore_engine/analyzers/malware.py)

--- a/content/docs/engine/general/concepts/images/analysis/content_hints.md
+++ b/content/docs/engine/general/concepts/images/analysis/content_hints.md
@@ -1,0 +1,102 @@
+---
+title: "Content Hints"
+linkTitle: "Content Hints"
+weight: 5
+---
+
+
+Anchore Engine includes the ability to read a user-supplied 'hints' file to allow users to override and/or augment the software artifacts that are discovered by anchore during its image analysis process.  The hints file, if present, contains records that describe a software package characteristics explicitly, and are then added to the software bill of materials (SBOM).  For example, if the owner of a CI/CD container build process knows that there are some software packages installed explicilty in a container image, but Anchore's regular analyzers are either not discovering the software or the analysis of the software package is incomplete, this mechanism can be used to include that information in the image's SBOM, exactly as if the package were discovered normally.
+
+### Configuration
+
+See [Configuring Content Hints]({{< ref "/docs/engine/engine_installation/configuration/content_hints" >}})
+
+Once enabled, the analyzer services will look for a file with a specific name, location and format located within the container image - ```/anchore_hints.json```.  The format of the file is illustrated using some examples, below.
+
+
+### OS Package Records
+
+OS Packages are those that will represent packages installed using OS / Distro style package managers.  Currently supported package types are ```rpm, dpkg, apkg``` for RedHat, Debian, and Alpine flavored package managers respectively.  Note that, for OS Packages, the name of the package is unique per SBOM, meaning that only one package named 'somepackage' can exist in an image's SBOM, and specifying a name in the hints file that conflicts with one with the same name discovered by the anchore analyzers will result in the record from the hints file taking precendence (override).
+
+* Minimum required values for a package record in anchore_hints.json
+
+```
+	{
+	    "name": "musl",
+	    "version": "1.1.20-r8",
+	    "type": "apkg"
+	}
+```
+
+* Complete record demonstrating all of the available characteristics of a software package that can be specified
+
+```
+	{
+	    "name": "musl",
+	    "version": "1.1.20",
+	    "release": "r8",
+	    "origin": "Timo Ter\u00e4s <timo.teras@iki.fi>",
+	    "license": "MIT",
+	    "size": "61440",
+	    "source": "musl",
+	    "files": ["/lib/ld-musl-x86_64.so.1", "/lib/libc.musl-x86_64.so.1", "/lib"],
+	    "type": "apkg"
+	}
+```
+
+### Non-OS/Language Package Records
+
+Non-OS / language package records are similar in form to the OS package records, but with some extra/different characteristics being supplied, namely the ```location``` field.  Since multiple non-os packages canbe installed that have the same name, the location field is particularly important as it is used to distinguish between package records that might otherwise be identical.  Valid types for non-os packages are currently ```java, python, gem, npm, nuget, go, binary```.  For the latest types that are available, see the ```anchore-cli image content <someimage>``` output, which lists available types for any given deployment of anchore engine.
+
+* Minimum required values for a package record in anchore_hints.json
+
+```
+	{
+	    "name": "wicked",
+	    "version": "0.6.1",  
+	    "type": "gem"
+	}
+```
+
+* Complete record demonstrating all of the available characteristics of a software package that can be specified
+
+```
+	{
+	    "name": "wicked",
+	    "version": "0.6.1",
+	    "location": "/app/gems/specifications/wicked-0.9.0.gemspec",
+	    "origin": "schneems",
+	    "license": "MIT",
+	    "source": "http://github.com/schneems/wicked",
+	    "files": ["README.md"],
+	    "type": "gem"	    
+	}
+```
+
+### Putting it all together
+
+Using the above examples, a complete anchore_hints.json file, when discovered by anchore engine located in ```/anchore_hints.json``` inside any container image, is provided here:
+
+```
+{
+    "packages": [
+	{
+	    "name": "musl",
+	    "version": "1.1.20-r8",
+	    "type": "apkg"
+	},
+	{
+	    "name": "wicked",
+	    "version": "0.6.1",  
+	    "type": "gem"
+	}
+    ]
+}
+```
+
+With such a hints file in an image based for example on ```alpine:latest```, the resulting image content would report these two package/version records as part of the SBOM for the analyzed image, when viewed using ```anchore-cli image content <image> os``` and ```anchore-cli image content <image> gem``` to view the ```musl``` and ```wicked``` package records, respectively.
+
+
+##### Note about using the hints file feature
+
+The hints file feature is disabled by default, and is meant to be used in very specific circumstances where a trusted entity is entrusted with creating and installing, or removing an anchore_hints.json file from all containers being built.  It is not meant to be enabled when the container image builds are not explicitly controlled, as the entity that is building container images could override any SBOM entry that anchore would normally discover, which effects the vulnerability/policy status of an image.  For this reason, the feature is disabled by default and must be explicitly enabled in configuration only if appropriate for your use case .

--- a/content/docs/engine/general/concepts/images/analysis/malware_scanning.md
+++ b/content/docs/engine/general/concepts/images/analysis/malware_scanning.md
@@ -1,0 +1,69 @@
+---
+title: "Malware Scanning"
+linkTitle: "Malware Scanning"
+weight: 2
+---
+
+## Overview
+
+Anchore Engine now supports the use of the open-source [ClamAV](https://clamav.net) malware scanner to detect malicious code embedded in container images.
+This scan occurs only at analysis time when the image content itself is available, and the scan results are available via the Engine API as well as for consumption
+in new policy gates to allow gating of image with malware findings.
+
+## Signature DB Updates
+
+Each analyzer service will run a malware signature update before analyzing each image. This does add some latency to the overall analysis time but ensures the signatures
+are as up-to-date as possible for each image analyzed. The update behavior can be disabled if you prefer to manage the freshness of the db via another route, such as a shared filesystem
+mounted to all analyzer nodes that is updated on a schedule. See the configuration section for details on disabling the db update.
+
+The status of the db update is present in each scan output for each image.
+
+
+## Scan Results
+
+The `malware` content type is a list of scan results. Each result is the run of a malware scanner, by default `clamav`.
+
+The list of files found to contain malware signature matches is in the `findings` property of each scan result. An empty array value indicates no matches found.
+
+The `metadata` property provides generic metadata specific to the scanner. For the ClamAV implemention, this includes the version data about the signature db used and
+if the db update was enabled during the scan. If the db update is disabled, then the `db_version` property of the metadata will not have values since the only way to get
+the version metadata is during a db udpate.
+
+```
+{
+    "content": [
+        {
+            "findings": [
+                {
+                    "path": "/somebadfile",
+                    "signature": "Unix.Trojan.MSShellcode-40"
+                },
+                {
+                    "path": "/somedir/somepath/otherbadfile",
+                    "signature": "Unix.Trojan.MSShellcode-40"
+                }
+            ],
+            "metadata": {
+                "db_update_enabled": true,
+                "db_version": {
+                    "bytecode": "331",
+                    "daily": "25890",
+                    "main": "59"
+                }
+            },
+            "scanner": "clamav"
+        }
+    ],
+    "content_type": "malware",
+    "imageDigest": "sha256:0eb874fcad5414762a2ca5b2496db5291aad7d3b737700d05e45af43bad3ce4d"
+}
+```
+
+## Policy Rules
+
+A policy gate called `malware` is available with a `scans` trigger that will fire for each file and signature combination found in the image so that you can fail an evaluation of an image
+if malware was detected during the analysis scan.
+
+See [policy checks]({{< ref "/docs/engine/usage/cli_usage/policies/policy_checks" >}}) for more details
+
+

--- a/content/docs/engine/quickstart/docker-compose.yaml
+++ b/content/docs/engine/quickstart/docker-compose.yaml
@@ -11,7 +11,7 @@ volumes:
 services:
   # The primary API endpoint service
   api:
-    image: anchore/anchore-engine:v0.7.3
+    image: anchore/anchore-engine:v0.8.0
     depends_on:
       - db
       - catalog
@@ -29,7 +29,7 @@ services:
 
   # Catalog is the primary persistence and state manager of the system
   catalog:
-    image: anchore/anchore-engine:v0.7.3
+    image: anchore/anchore-engine:v0.8.0
     depends_on:
       - db
     logging:
@@ -44,7 +44,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "catalog"]
   queue:
-    image: anchore/anchore-engine:v0.7.3
+    image: anchore/anchore-engine:v0.8.0
     depends_on:
       - db
       - catalog
@@ -60,7 +60,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "simplequeue"]
   policy-engine:
-    image: anchore/anchore-engine:v0.7.3
+    image: anchore/anchore-engine:v0.8.0
     depends_on:
       - db
       - catalog
@@ -76,7 +76,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "policy_engine"]
   analyzer:
-    image: anchore/anchore-engine:v0.7.3
+    image: anchore/anchore-engine:v0.8.0
     depends_on:
       - db
       - catalog

--- a/content/docs/engine/releasenotes/080.md
+++ b/content/docs/engine/releasenotes/080.md
@@ -1,0 +1,73 @@
+---
+title: "Anchore Engine Release Notes - Version 0.8.0"
+linkTitle: "0.8.0"
+weight: 60
+---
+
+## Anchore Engine 0.8.0
+
+Anchore Engine 0.8.0, features, bug fixes, and improvements.  The latest summary can always be found in the Anchore Engine [CHANGELOG](https://github.com/anchore/anchore-engine/blob/master/CHANGELOG.md) on github.
+
+### Malware Scanning
+
+Of specific note, 0.8.0 adds malware scanning capabilities, makes deletion of images asynchronous, and adds new analyzers for binaries not delivered in packages (python, go, and busybox) as well
+as a new "hints" capability in the analyzers to allow developers or image builders to pass metadata to the analyzers to help detection or augmentation of analysis with artifacts that would otherwise
+not be detected.
+
+For more information see: [Malware Scanning]({{<ref "/docs/engine/general/concepts/images/analysis/malware_scanning" >}})
+
+### New Binary Content Type
+
+A new binary analyzer, enabled by default, will check for and statically inspect binaries that are often installed outside of package managers to support a common use-case of language or runtime-specific base images
+such as python and go images where the runtime is installed via an archive and thus no package db entry exists. The analyzer supports specific binaries that it searches and can get metadata for: go, python, and busybox.
+
+Once detected, these are matched for vulnerabilities just like regular packages using the NVD and other non-OS vulnerability sources.
+
+### Content Hints
+
+A new "hints" feature allows users to pass specific metadata into the analyzers to help identify and augment content that would not have been discovered by existing analyzers. This is particularly useful
+if you have libraries statically compiled into another binary or installed outside of a package manager that you want to tell Anchore about so you can get vulnerability matches for and include them in the
+image's content manifests. This is accomplished with a specific json file present in the image: ```/anchore_hints.json```. The entries are merged into the analyzer results to augment their findings for
+different content types.
+
+For more information, see: [Content Hints]({{< ref "/docs/engine/general/concepts/images/analysis/content_hints" >}})
+
+### Changed Image Deletion Behavior
+
+In this release, image deletion is now an asynchronous operatin and the image_status property in the image record now has possible states 'active' and 'deleting'. Deletion of an image by API call will
+transition the image record to a 'deleting' status as indicated by the image_status property and will be deleted by asynchronous processes on a duty cycle. This helps balance database load under a high volume
+of delete operations and also makes the client-percieved response time much lower. 
+
+*NOTE: Responses for `GET /images` and `GET /summaries/imagetags` do *not* include images in the deleting state by default, though new query parameters
+allow those images to be returned in those calls if desired (`image_status=deleting` or `image_status=all`)*
+
+
+### New API Revision
+
+The API is updated to version [0.1.15](https://github.com/anchore/anchore-engine/blob/v0.8.0/anchore_engine/services/apiext/swagger/swagger.yaml)
+
+### Added
+
++ Changed image deletion to asynchronous behavior to make API more responsive and throttle db load during image deletes.
++ New dry-run mode for repository scan request to return list of tags that would be scanned without actually scanning or persisting the record. Implements [510](https://github.com/anchore/anchore-engine/issues/510)
++ Support for a "hints" json file in the image. JSON file to pass additional metadata to augment analyzer findings. Implements [550](https://github.com/anchore/anchore-engine/issues/550)
++ Adds API support for deleting multiple images in a single call. Implements [502](https://github.com/anchore/anchore-engine/issues/502)
++ Support for malware scanning using ClamAV and new 'malware' content type in API and policy gate to trigger on findings. Disabled by default. Implements [498](https://github.com/anchore/anchore-engine/issues/498)     
++ Support for content type 'binary' with analyzers to detect specific binaries: python, golang, busybox not installed by package manager. Implements [531](https://github.com/anchore/anchore-engine/issues/531), [533](https://github.com/anchore/anchore-engine/issues/533), [534](https://github.com/anchore/anchore-engine/issues/534), [340](https://github.com/anchore/anchore-engine/issues/340)
++ Query parameter filters for GET /images calls to filter by image_status and analysis_status. Implements [561](https://github.com/anchore/anchore-engine/issues/561)
+
+### Improved
+
++ Change image analysis queue processing behavior from first come first served to fair share accross account. Implements [491](https://github.com/anchore/anchore-engine/issues/491)
++ Removes image_to_get property in GET body of /images route, since body in GET operations is not standard behavior. Fixes [562](https://github.com/anchore/anchore-engine/issues/562)
+
+### Fixes 
++ Handle scratch images correctly in files gate behavior. Fixes [503](https://github.com/anchore/anchore-engine/issues/530)
++ Add missing fields in swagger json spec for GET /query/vulnerabilities. Fixes [558](https://github.com/anchore/anchore-engine/issues/558)
++ Better handling of java packages missing certain metadata in MANIFEST.MF files. Fixes [524](https://github.com/anchore/anchore-engine/issues/524)
+
+Additional minor bug fixes and enhancements
+
+### Upgrading
+
+* [Upgrading Anchore Engine]({{< ref "/docs/engine/engine_installation/upgrade" >}})

--- a/content/docs/engine/releasenotes/080.md
+++ b/content/docs/engine/releasenotes/080.md
@@ -29,7 +29,7 @@ Once detected, these are checked for vulnerabilities, just like regular packages
 
 A new "hints" feature allows users to pass specific metadata into the analyzers to help identify and augment content that existing analyzers would not have been discovered. This feature is useful
 if you have libraries statically compiled into another binary or installed outside of a package manager that you want to tell Anchore about so you can get vulnerability matches for and include them in the
-image's content manifests. This is accomplished with a specific json file present in the image: ```/anchore_hints.json```. The entries are merged into the analyzer results to augment their findings for
+image's content manifests. This is accomplished with a specific JSON file present in the image: ```/anchore_hints.JSON```. The entries are merged into the analyzer results to augment their findings for
 different content types.
 
 For more information, see: [Content Hints]({{< ref "/docs/engine/general/concepts/images/analysis/content_hints" >}})
@@ -52,7 +52,7 @@ The API is updated to version [0.1.15](https://github.com/anchore/anchore-engine
 
 + Changed image deletion to asynchronous behavior to make API more responsive and throttle db load during image deletes.
 + New dry-run mode for repository scan request to return list of tags that would be scanned without scanning or persisting the record. Implements [510](https://github.com/anchore/anchore-engine/issues/510)
-+ Support for a "hints" json file in the image. JSON file to pass additional metadata to augment analyzer findings. Implements [550](https://github.com/anchore/anchore-engine/issues/550)
++ Support for a "hints" JSON file in the image. JSON file to pass additional metadata to augment analyzer findings. Implements [550](https://github.com/anchore/anchore-engine/issues/550)
 + Adds API support for deleting multiple images in a single call. Implements [502](https://github.com/anchore/anchore-engine/issues/502)
 + Support for malware scanning using ClamAV and new 'malware' content type in API and policy gate to trigger on findings. Disabled by default. Implements [498](https://github.com/anchore/anchore-engine/issues/498)     
 + Support for content type 'binary' with analyzers to detect specific binaries: python, golang, busybox not installed by package manager. Implements [531](https://github.com/anchore/anchore-engine/issues/531), [533](https://github.com/anchore/anchore-engine/issues/533), [534](https://github.com/anchore/anchore-engine/issues/534), [340](https://github.com/anchore/anchore-engine/issues/340)
@@ -60,12 +60,12 @@ The API is updated to version [0.1.15](https://github.com/anchore/anchore-engine
 
 ### Improved
 
-+ Change image analysis queue processing behavior from first come first served to fair share accross account. Implements [491](https://github.com/anchore/anchore-engine/issues/491)
++ Change image analysis queue processing behavior from first come first served to fair share across accounts. Implements [491](https://github.com/anchore/anchore-engine/issues/491)
 + Removes image_to_get property in GET body of /images route, since body in GET operations is not standard behavior. Fixes [562](https://github.com/anchore/anchore-engine/issues/562)
 
 ### Fixes 
 + Handle scratch images correctly in files gate behavior. Fixes [503](https://github.com/anchore/anchore-engine/issues/530)
-+ Add missing fields in swagger json spec for GET /query/vulnerabilities. Fixes [558](https://github.com/anchore/anchore-engine/issues/558)
++ Add missing fields in swagger JSON spec for GET /query/vulnerabilities. Fixes [558](https://github.com/anchore/anchore-engine/issues/558)
 + Better handling of java packages missing certain metadata in MANIFEST.MF files. Fixes [524](https://github.com/anchore/anchore-engine/issues/524)
 
 Additional minor bug fixes and enhancements

--- a/content/docs/engine/releasenotes/080.md
+++ b/content/docs/engine/releasenotes/080.md
@@ -8,24 +8,26 @@ weight: 60
 
 Anchore Engine 0.8.0, features, bug fixes, and improvements.  The latest summary can always be found in the Anchore Engine [CHANGELOG](https://github.com/anchore/anchore-engine/blob/master/CHANGELOG.md) on github.
 
-### Malware Scanning
+Of specific note, 0.8.0 adds: malware scanning capabilities, makes deletion of images asynchronous, adds new analyzers for binaries not delivered in packages, and includes a "content hints" capability in the 
+analyzers so developers or image builders can pass metadata to augmentation analysis results.
 
-Of specific note, 0.8.0 adds malware scanning capabilities, makes deletion of images asynchronous, and adds new analyzers for binaries not delivered in packages (python, go, and busybox) as well
-as a new "hints" capability in the analyzers to allow developers or image builders to pass metadata to the analyzers to help detection or augmentation of analysis with artifacts that would otherwise
-not be detected.
+
+### Malware Scanning
+Engine 0.8.0 now integrates ClamAV for optional (disabled by default) malware scanning of image content during the analysis phase and with policy rules to trigger on findings. This is particularly useful for using Engine to validate
+external images in an image catalog or "golden repo" where you must guard against both vulnerable and malicious code from external sources. 
 
 For more information see: [Malware Scanning]({{<ref "/docs/engine/general/concepts/images/analysis/malware_scanning" >}})
 
 ### New Binary Content Type
 
-A new binary analyzer, enabled by default, will check for and statically inspect binaries that are often installed outside of package managers to support a common use-case of language or runtime-specific base images
-such as python and go images where the runtime is installed via an archive and thus no package db entry exists. The analyzer supports specific binaries that it searches and can get metadata for: go, python, and busybox.
+A new binary analyzer will check for and inspect binaries that are often installed outside of package managers. This supports a common use-case of language or runtime-specific base images
+such as Python and Go images where the runtime is installed via an archive and thus no package db entry exists. The analyzer supports specific binaries that it searches and can get metadata for: Go, Python, and BusyBox.
 
-Once detected, these are matched for vulnerabilities just like regular packages using the NVD and other non-OS vulnerability sources.
+Once detected, these are checked for vulnerabilities, just like regular packages using the NVD and other non-OS vulnerability sources.
 
 ### Content Hints
 
-A new "hints" feature allows users to pass specific metadata into the analyzers to help identify and augment content that would not have been discovered by existing analyzers. This is particularly useful
+A new "hints" feature allows users to pass specific metadata into the analyzers to help identify and augment content that existing analyzers would not have been discovered. This feature is useful
 if you have libraries statically compiled into another binary or installed outside of a package manager that you want to tell Anchore about so you can get vulnerability matches for and include them in the
 image's content manifests. This is accomplished with a specific json file present in the image: ```/anchore_hints.json```. The entries are merged into the analyzer results to augment their findings for
 different content types.
@@ -34,9 +36,9 @@ For more information, see: [Content Hints]({{< ref "/docs/engine/general/concept
 
 ### Changed Image Deletion Behavior
 
-In this release, image deletion is now an asynchronous operatin and the image_status property in the image record now has possible states 'active' and 'deleting'. Deletion of an image by API call will
-transition the image record to a 'deleting' status as indicated by the image_status property and will be deleted by asynchronous processes on a duty cycle. This helps balance database load under a high volume
-of delete operations and also makes the client-percieved response time much lower. 
+Image deletion is now an asynchronous operation and the `image_status` property in the image record now has possible states 'active' and 'deleting'. Deletion of an image by API call will
+transition the image record to a `deleting` status as indicated by the `image_status` property. Images in that state will be deleted by an asynchronous process on a duty cycle. This approach helps manage database 
+load under a high volume of delete operations and also makes the client-perceived response time much lower. 
 
 *NOTE: Responses for `GET /images` and `GET /summaries/imagetags` do *not* include images in the deleting state by default, though new query parameters
 allow those images to be returned in those calls if desired (`image_status=deleting` or `image_status=all`)*
@@ -49,7 +51,7 @@ The API is updated to version [0.1.15](https://github.com/anchore/anchore-engine
 ### Added
 
 + Changed image deletion to asynchronous behavior to make API more responsive and throttle db load during image deletes.
-+ New dry-run mode for repository scan request to return list of tags that would be scanned without actually scanning or persisting the record. Implements [510](https://github.com/anchore/anchore-engine/issues/510)
++ New dry-run mode for repository scan request to return list of tags that would be scanned without scanning or persisting the record. Implements [510](https://github.com/anchore/anchore-engine/issues/510)
 + Support for a "hints" json file in the image. JSON file to pass additional metadata to augment analyzer findings. Implements [550](https://github.com/anchore/anchore-engine/issues/550)
 + Adds API support for deleting multiple images in a single call. Implements [502](https://github.com/anchore/anchore-engine/issues/502)
 + Support for malware scanning using ClamAV and new 'malware' content type in API and policy gate to trigger on findings. Disabled by default. Implements [498](https://github.com/anchore/anchore-engine/issues/498)     

--- a/content/docs/engine/releasenotes/_index.md
+++ b/content/docs/engine/releasenotes/_index.md
@@ -4,6 +4,7 @@ linkTitle: "Release Notes"
 weight: 7
 ---
 
+* [Anchore Engine Version 0.8.0]({{< ref "/docs/engine/releasenotes/080.md" >}})
 * [Anchore Engine Version 0.7.3]({{< ref "/docs/engine/releasenotes/073.md" >}})
 * [Anchore Engine Version 0.7.2]({{< ref "/docs/engine/releasenotes/072.md" >}})
 * [Anchore Engine Version 0.7.1]({{< ref "/docs/engine/releasenotes/071.md" >}})

--- a/content/docs/engine/usage/cli_usage/images/inspecting_image_content.md
+++ b/content/docs/engine/usage/cli_usage/images/inspecting_image_content.md
@@ -24,6 +24,8 @@ the CONTENT_TYPE can be one of the following types:
 - java: Java Archives
 - python: Python Artifacts
 - nuget: .NET NuGet Artifacts
+- malware: malware findings from scanners (default is ClamAV)
+- binary: specific binaries that are statically checked for metadata (e.g. python and go runtime)
 
 For example: `anchore-cli image content debian:latest files`
 

--- a/content/docs/engine/usage/cli_usage/policies/policy_checks.md
+++ b/content/docs/engine/usage/cli_usage/policies/policy_checks.md
@@ -9,4 +9,30 @@ Information about the latest available policy gates, triggers and parameters can
 
 `# anchore-cli policy describe (--gate <gatename> ( --trigger <triggername))`
 
-For an independent list of available gates/triggers, refer to [Anchore Policy Checks]({{< ref "/docs/overview/concepts/policy/policy_checks" >}})
+
+## Gates
+
+| Gate            | Description                                                |
+|-----------------|------------------------------------------------------------|
+| always          | Triggers that fire unconditionally if present in policy, useful for things like testing and blacklisting
+| dockerfile      | Checks against the content of a dockerfile if provided, or a guessed dockerfile based on docker layer history if the dockerfile is not provided
+| files           | Checks against files in the analyzed image including file  content, file names, and filesystem attributes
+| licenses        | License checks against found software licenses in the container image
+| malware         | Checks for malware scan findings in the image              
+| metadata        | Checks against image metadata, such as size, OS, distro, architecture, etc.
+| npms            | NPM Checks
+| packages        | Distro package checks
+| passwd_file     | Content checks for /etc/passwd for things like usernames, group ids, shells, or full entries
+| retrieved_files | Checks against content and/or presence of files retrieved at analysis time from an image
+| ruby_gems       | Ruby Gem Checks
+| secret_scans    | Checks for secrets and content found in the image using configured regexes found in the "secret_search" section of analyzer_config.yaml
+| vulnerabilities | CVE/Vulnerability checks
+
+### Gate: Malware
+
+| Trigger | Description                        | Parameters |
+|---------|------------------------------------|------------|
+| scans   | Triggers if the ClamAV scanner has found any matches in the image.  |  |
+
+
+For a more in-depth list of available gates/triggers, refer to [Anchore Policy Checks]({{< ref "/docs/overview/concepts/policy/policy_checks" >}})


### PR DESCRIPTION
Includes engine-only docs for: malware scanning, content hints, and image deletion changes.

Signed-off-by: Zach Hill <zach@anchore.com>

Co-authored-by: Zach Hill <zach@anchore.com>
Co-authored-by: Dan Nurmi <nurmi@anchore.com>