### PR TITLE
Delete malware gate triggers from Policy Checks page

### DIFF
--- a/content/docs/engine/usage/cli_usage/policies/policy_checks.md
+++ b/content/docs/engine/usage/cli_usage/policies/policy_checks.md
@@ -28,11 +28,4 @@ Information about the latest available policy gates, triggers and parameters can
 | secret_scans    | Checks for secrets and content found in the image using configured regexes found in the "secret_search" section of analyzer_config.yaml
 | vulnerabilities | CVE/Vulnerability checks
 
-### Gate: Malware
-
-| Trigger | Description                        | Parameters |
-|---------|------------------------------------|------------|
-| scans   | Triggers if any malware scanner has found any matches in the image.  |  |
-| scan_not_run | Triggers if no scan was found for the image. | | 
-
 For a more in-depth list of available gates/triggers, refer to [Anchore Policy Checks]({{< ref "/docs/overview/concepts/policy/policy_checks" >}})


### PR DESCRIPTION
Content deleted in this commit is repetitive, probably a copy-paste error. Correct page for describing malware gate triggers is https://docs.anchore.com/current/docs/overview/concepts/policy/policy_checks/#gate-malware 