### PR TITLE
add healthcheck for feeds-db

### DIFF
--- a/content/docs/quickstart/docker-compose.yaml
+++ b/content/docs/quickstart/docker-compose.yaml
@@ -308,6 +308,8 @@ services:
 #      driver: "json-file"
 #      options:
 #        max-size: 100m
+#    healthcheck:
+#      test: ["CMD-SHELL", "pg_isready -U postgres"]
 #  feeds:
 #    image: docker.io/anchore/enterprise:v2.4.0
 #    volumes:


### PR DESCRIPTION
feeds-db doesn't have a healthcheck defined and postgres doesn't have one defined by default