### PR TITLE
add healthcheck to enterprise-feeds-db service

### DIFF
--- a/content/docs/quickstart/docker-compose.yaml
+++ b/content/docs/quickstart/docker-compose.yaml
@@ -308,6 +308,8 @@ services:
 #      driver: "json-file"
 #      options:
 #        max-size: 100m
+#    healthcheck:
+#      test: ["CMD-SHELL", "pg_isready -U postgres"]
 #  feeds:
 #    image: docker.io/anchore/enterprise:v2.4.0
 #    volumes:


### PR DESCRIPTION
postgres does not have a HEALTHCHECK defined by default, so I'm adding one to the enterprise-feeds-db service.

Signed-off-by: Paul V. Novarese pvn@novarese.net