### PR TITLE
Updated mount path specified for analyzer configuration overrides

### DIFF
--- a/content/docs/installation/configuration/malware.md
+++ b/content/docs/installation/configuration/malware.md
@@ -8,7 +8,7 @@ weight: 8
 
 See [Malware Scanning]({{< ref "/docs/engine/general/concepts/images/analysis/malware_scanning" >}}) for an overview of the feature and how it works. This section is for configuration of scan behavior.
 
-Customizing the `analyzer_config.yaml` requires a restart of the analyzer container. The typical process is to mount it externally into `/config/analyzer_config.yaml` from a host volume or as a ConfigMap in Kubernetes and
+Customizing the `analyzer_config.yaml` requires a restart of the analyzer container. The typical process is to mount it externally into `/anchore_service/analyzer_config.yaml` from a host volume or as a ConfigMap in Kubernetes and
 all analyzers in the deployment share the same configuration.
 
 ## Enabling & Disabling Malware Scans


### PR DESCRIPTION
Fixed outdated configuration path for analyzer config. Only made the change in the enterprise docs section in anticipation of engine docs being removed. Will need to put change in engine docs once that is completed

Fixes #251

Signed-off-by: Zane Burstein <zane.burstein@anchore.com>