### PR TITLE
Update compose and configuration with default admin password

### DIFF
--- a/content/docs/installation/configuration/config.md
+++ b/content/docs/installation/configuration/config.md
@@ -12,7 +12,7 @@ Each environment variable (starting with ANCHORE_) in the default config.yaml is
 
 Some examples of useful initial settings follow.
 
-* Default admin credentials: by default, the **admin** has a password of **foobar** and email **admin@myanchore**, set using the **ANCHORE_ADMIN_PASSWORD** and **ANCHORE_ADMIN_EMAIL** environment variables, respectively, in the Dockerfile.  To change these settings, simply add overrides for **ANCHORE_ADMIN_PASSWORD** and **ANCHORE_ADMIN_EMAIL** environment variables, set to your preferred values prior to deploying anchore engine.
+* Default admin credentials: A default admin email and password is required to be defiend in the catalog service for the initial bootstrap of enterprise to succeed, which are both set through the default config file using the **ANCHORE_ADMIN_PASSWORD** and **ANCHORE_ADMIN_EMAIL** environment variables respectively. The Dockerfile defines a default email **admin@myanchore**, but does not define a default password. If using the default config file, the user must set a value for **ANCHORE_ADMIN_PASSWORD** in order to succeed the initial bootstrap of the system. To set the default password or to override the default email, simply add overrides for **ANCHORE_ADMIN_PASSWORD** and **ANCHORE_ADMIN_EMAIL** environment variables, set to your preferred values prior to deploying anchore engine. After the initial bootstrap, this can be removed if desired. The docker-compose file referenced in the quickstart installation guide has set **ANCHORE_ADMIN_PASSWORD** to `foobar` on the catalog service already
 ```YAML
 default_admin_password: '${ANCHORE_ADMIN_PASSWORD}'
 default_admin_email: '${ANCHORE_ADMIN_EMAIL}'

--- a/content/docs/quickstart/docker-compose.yaml
+++ b/content/docs/quickstart/docker-compose.yaml
@@ -61,6 +61,7 @@ services:
       - ANCHORE_ENABLE_METRICS=false
       - ANCHORE_LOG_LEVEL=INFO
       - ANCHORE_CATALOG_NOTIFICATION_INTERVAL_SEC=0
+      - ANCHORE_ADMIN_PASSWORD=foobar
       # Uncomment both ANCHORE_OAUTH_ENABLED and ANCHORE_AUTH_SECRET to enable SSO feature of anchore-enterprise
       #- ANCHORE_OAUTH_ENABLED=true
       #- ANCHORE_AUTH_SECRET=supersharedsecret


### PR DESCRIPTION
Updates the docs to reflect the changes made in https://github.com/anchore/anchore-engine/issues/810. In enterprise the  default password only needs to be defined on the catalog service

Signed-off-by: Zane Burstein <zane.burstein@anchore.com>