### PR TITLE
Update max image size docs

### DIFF
--- a/content/docs/installation/configuration/_index.md
+++ b/content/docs/installation/configuration/_index.md
@@ -18,6 +18,7 @@ All system (except the UI, which has its own configuration) services require a s
 - [Enterprise Feeds Service]({{< ref "/docs/installation/feeds" >}})
 - [Enterprise RBAC Module]({{< ref "/docs/installation/rbac" >}})
 - [Storage Configuration]({{< ref "/docs/installation/storage" >}})
+- [Max Image Size]({{< ref "/docs/installation/configuration/max_image_size" >}})
 
 
 **NOTE** - The latest default configuration file can always be extracted from the Enterprise container to review the latest options and environment overrides using the following process:

--- a/content/docs/installation/configuration/max_image_size.md
+++ b/content/docs/installation/configuration/max_image_size.md
@@ -1,0 +1,10 @@
+---
+title: "Max Image Size"
+linkTitle: "Max Image Size"
+weight: 5
+---
+
+## Setting Size Filter
+As of v3.0, Anchore Enterprise can be configured to have a size limit for images being added for analysis. Images that exceed the configured maximum size will not be added to Anchore and the catalog service will log an error message providing details of the failure. This size limit is applied when adding images to anchore via the [api/cli]({{< ref "docs/using/cli_usage/images/_index.md#adding-an-image" >}}), [tag subscriptions]({{< ref "docs/using/cli_usage/subscriptions/_index.md#tag-updates" >}}), and [repository watchers]({{< ref "/docs/using/cli_usage/repositories/_index.md#watching-repositories" >}}).
+
+The max size feature is disabled by default but can be enabled via  `max_compressed_image_size_mb` in the configuration file, which represents the size limit in MB of the compressed image. Values less than 0 will disable the feature and allow images of any size to be added to Anchore. A value of 0 will be enforced and prevent any images from being added. Non-integer values will cause bootstrap of the service to fail. If using compose with the default config, this can be set through the `ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB` env variable on the catalog service. If using helm, it can be defined in the values file via `anchoreGlobal.maxCompressedImageSizeMB`

--- a/content/docs/using/cli_usage/images/_index.md
+++ b/content/docs/using/cli_usage/images/_index.md
@@ -36,10 +36,7 @@ For an image that has not yet been analyzed, the status will appear as *not_anal
 
 The image type is shown as `docker`, future release will support the analysis of OCI formatted images.
 
-As of v3.0, Anchore Enterprise can be configured to have a size limit for images being added for analysis. Images that exceed the configured maximum size will not be added to Anchore and the catalog service will log a message. This size limit is also applied to [tag subscriptions]({{< ref "docs/using/cli_usage/subscriptions/_index.md#tag-updates" >}}) and [repository watchers]({{< ref "/docs/using/cli_usage/repositories/_index.md#watching-repositories" >}}) in addition to the standard API for adding images to Anchore for analysis. 
-
-The max size feature is disabled by default but can be enabled through the `max_compressed_image_size_mb` configuration variable, which represents the size limit in MB of the compressed image. Values less than 0 will disable the feature and allow images of any size to be added to Anchore. A value of 0 will be enforced and prevent any images from being added. Non-integer values will cause bootstrap of the service to fail. If using compose with the default config, this can be set through the `ANCHORE_MAX_COMPRESSED_IMAGE_SIZE_MB` env variable on the catalog service. If using helm, it can be defined in the values file via `anchoreGlobal.maxCompressedImageSizeMB`
-
+As of v3.0, Anchore Enterprise can be configured to have a size limit for images being added for analysis. Attempting to add an image that exceeds the configured size will fail, return a 400 API error, and log an error message in the catalog service detailing the failure. This feature is disabled by default so see [documentation]({{< ref "docs/installation/configuration/max_image_size.md" >}}) for additional details on the functionality of this feature and instructions on how to configure the limit
 
 
 ### Adding images that you own

--- a/content/docs/using/cli_usage/repositories/_index.md
+++ b/content/docs/using/cli_usage/repositories/_index.md
@@ -70,7 +70,7 @@ The repo watch command instructs Anchore Enterprise to monitor a repository for 
 
 `$ anchore-cli repo watch repo.example.com/myrepo`
 
-Note that [max image size]({{< ref "/docs/using/cli_usage/images/_index.md#adding-an-image" >}}) applies to the repository watcher. Images that exceed the max configured size in the repo being watched will not be added and a message will be logged in the catalog service. 
+As of v3.0, Anchore Enterprise can be configured to have a size limit for images being added for analysis. This feature applies to the repo watcher. Images that exceed the max configured size in the repo being watched will not be added and a message will be logged in the catalog service. This feature is disabled by default so see [documentation]({{< ref "docs/installation/configuration/max_image_size.md" >}}) for additional details on the functionality of this feature and instructions on how to configure the limit
 
 ## Removing a Repository and All Images
 

--- a/content/docs/using/cli_usage/subscriptions/_index.md
+++ b/content/docs/using/cli_usage/subscriptions/_index.md
@@ -20,7 +20,7 @@ For example, if you had a subscription to the docker.io/library/node:latest tag 
 
 This subscription is activated automatically when a new tag is added to Anchore Enterprise.
 
-The configuration for a [max image size]({{< ref "/docs/using/cli_usage/images/_index.md#adding-an-image" >}}) applies to tag updates. If the new image associated with the tag exceeds the defined limit then it will fail to update in anchore and an error message will be logged in the catalog service. 
+As of v3.0, Anchore Enterprise can be configured to have a size limit for images being added for analysis. This limit applies to tag subscriptions. If the new image associated with the tag exceeds the defined limit then it will fail to update in anchore and an error message will be logged in the catalog service. This feature is disabled by default so see [documentation]({{< ref "docs/installation/configuration/max_image_size.md" >}}) for additional details on the functionality of this feature and instructions on how to configure the limit
 
 **Note:** If this subscription is disabled Anchore Enterprise will not monitor the registry for new images.
 


### PR DESCRIPTION
Per @zhill , giving max image size configuration instructions/details its own page in config dir. 