### PR TITLE
Missing cat

### DIFF
--- a/content/docs/installation/configuration/custom_certs.md
+++ b/content/docs/installation/configuration/custom_certs.md
@@ -34,7 +34,7 @@ FROM docker.io/anchore/anchore-engine:v0.4.0
 USER root:root
 COPY ./custom-ca.pem /usr/local/lib/python3.6/site-packages/certifi/
 RUN update-ca-trust
-RUN /usr/local/lib/python3.6/site-packages/certifi/custom-ca.pem >> /usr/lib/python3.6/site-packages/certifi/cacert.pem
+RUN /usr/bin/cat /usr/local/lib/python3.6/site-packages/certifi/custom-ca.pem >> /usr/lib/python3.6/site-packages/certifi/cacert.pem
 USER anchore:anchore
 
 ```


### PR DESCRIPTION
Executing a pem is just going to give permission denied.

Signed-off-by: Joseph Price <j.price@kainos.com>