### PR TITLE
Adds Kubernetes Inventory UI

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -19,8 +19,8 @@ linkTitle = "Anchore Enterprise Documentation"
 
 {{% blocks/section title="Integrations" subtitle="Integrate Anchore with your favorite CI/CD Systems, Orchestration Platforms, and more" color="primary" %}}
 
-{{% blocks/feature svg="icons/kubernetes-logo.svg" title="Kubernetes" %}}
-Install Anchore using the [Helm Chart](https://github.com/anchore/anchore-charts/blob/master/stable/anchore-engine) and make admission decisions based on analysis and policy-based evaluations with our [Kubernetes Admission Controller](https://github.com/anchore/kubernetes-admission-controller)
+{{% blocks/feature svg="icons/kubernetes-logo.svg" href="/docs/using/ui_usage/kubernetes/" title="Kubernetes" %}}
+Track the inventory of your running containers with our [Kubernetes Automated Inventory Agent (KAI)](https://github.com/anchore/kai), or enforce security policies across your clusters using our [Kubernetes Admission Controller](https://github.com/anchore/kubernetes-admission-controller)
 {{% /blocks/feature %}}
 
 {{% blocks/feature svg="icons/jenkins-logo.svg" title="Jenkins" %}}

--- a/content/docs/overview/concepts/images/inventory/_index.md
+++ b/content/docs/overview/concepts/images/inventory/_index.md
@@ -1,153 +1,62 @@
 ---
-title: "Image Runtime Inventory"
-linkTitle: "Image Inventory"
+title: "Kubernetes Runtime Inventory"
+linkTitle: "Kubernetes Runtime  Inventory"
 weight: 1
 ---
 
-Anchore can connect to your runtime environment and discern which images exist in each context (i.e. Kubernetes Namespace).
-
-Currently, supported runtime environments include:
-* Kubernetes
-
-# Kubernetes Runtime Inventory 
 ## Configuration
-Anchore uses a go binary called [kai](https://github.com/anchore/kai) that leverages the [Kubernetes Go SDK](https://github.com/kubernetes/client-go) to reach out and list
-pods in a configurable set of namespaces to determine which images are running.
+Anchore uses a go binary called [kai](https://github.com/anchore/kai) that leverages the [Kubernetes Go SDK](https://github.com/kubernetes/client-go) to reach out and list pods in a configurable set of namespaces to determine which images are running.
 
 This binary is installed into the Enterprise Docker Image and can be configured using the REST API, but depends on Anchore knowing your cluster configuration and corresponding credentials. On the other hand, `kai` can also be run via it's helm chart, embedded within your Kubernetes cluster as an agent. In this run-mode, it will require access to the Anchore API.  
 
-## Embedded mode
+## Agent Mode
+The most common way to track inventory is to install [`kai`](https://github.com/anchore/kai). as an agent in your cluster. To do this you will need to configure credentials
+and information about your deployment in the values file. It is recommended to first [configure a specific robot user](/current/docs/using/cli_usage/user_management/) for the account you'll want to track your inventory in. 
 
-In embedded mode, `kai` runs within the Enterprise Image, and needs a cluster configuration to access the Kubernetes API.
-
-Authentication with the Kubernetes API can be done similarly to how a kubeconfig is configured. Anchore supports either a Service Account token (recommended) or a client private key/certificate combination.
-
-### Generating a Service Account Token
-To generate a Service Account token with the necessary permissions (view), follow these steps:
-1. Create a Service Account: `$ kubectl create serviceaccount <name> -n <namespace>`
-    * ex. `$ kubectl create serviceaccount anchore-runtime-inventory -n default`
-1. Bind the Service Account to a Role: `$ kubectl create clusterrolebinding <binding-name> --clusterrole=view --serviceaccount=<namespace>:<name>`
-    * ex. `$ kubectl create clusterrolebinding anchore-runtime-inventory-binding --clusterrole=view --serviceaccount=default:anchore-runtime-inventory`
-1. Get the token name: ```$ TOKENNAME=`kubectl -n <namespace> get serviceaccount/<name> -o jsonpath='{.secrets[0].name}'` ```
-    * ex. ```$ TOKENNAME=`kubectl -n default get serviceaccount/anchore-runtime-inventory -o jsonpath='{.secrets[0].name}'` ```
-1. Get the token value, which corresponds to the "credential" field below: ```$ TOKEN=`kubectl -n <namespace> get secret $TOKENNAME -o jsonpath='{.data.token}'` ```
-    * ex. ```$ TOKEN=`kubectl -n default get secret $TOKENNAME -o jsonpath='{.data.token}'` ```
-
-The endpoints for configuring the cluster within Anchore are documented under the Enterprise Swagger route, but are also demonstrated below:
-```shell script
-$ cat kai-demo-cluster.json
-{
-	"cluster_name": "docker-desktop-token",
-	"inventory_type": "kubernetes",
-	"cluster_config": {
-		"cluster_certificate": "ABC", # redacted
-		"cluster_server": "https://kubernetes.docker.internal:6443",
-		"credential": "XYZ", #redacted
-		"credential_type": "token",
-		"namespaces": [
-			"all"
-		]
-	}
-}
-$ curl -X POST -u admin:foobar -H "Content-Type: application/json" --data-binary "@kai-demo-cluster.json" "http://localhost:8228/v1/enterprise/inventories/clusters"
-```
-Some of the fields above within the `cluster_config` correspond to fields you would see in your kubeconfig:
-* **cluster_certificate:** corresponds to `clusters[0].cluster.certificate-authority-data`
-* **cluster_server:** corresponds to `clusters[0].cluster.server`
-* **credential:** corresponds to either a service account token or the private key of a user. Note: if a private key is supplied, then a **client_certificate** must also be specified. 
-    * The private key may be found at `users[0].user.client-key-data`.
-    * The token, if included in a kubeconfig, would be found at `users[0].user.token`
-* **client_certificate:** (required only for private key authentication), corresponds to `users[0].user.client-certificate-data`
-* **credential_type:** values can either be "token" or "private_key" 
-* **namespaces:** configures which namespaces anchore will pull a runtime inventory from
-
-#### Example
-
-Consider this kubeconfig, which has both a service-account-token authenticated user as well as a private_key-authenticated user:
-```
-apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority-data: abc
-    server: https://kubernetes.docker.internal:6443
-  name: docker-desktop
-contexts:
-- context:
-    cluster: docker-desktop
-    user: docker-desktop
-  name: docker-desktop
-current-context: docker-desktop
-kind: Config
-preferences: {}
-users:
-- name: docker-desktop
-  user:
-    client-certificate-data: def
-    client-key-data: ghi
-- name: kai-demo
-  user:
-    token: jkl
-```
-
-The corresponding Cluster Config JSON for the Service Account Token authentication would be:
-```json
-{
-	"cluster_name": "docker-desktop-token",
-	"inventory_type": "kubernetes",
-	"cluster_config": {
-		"cluster_certificate": "abc",
-		"cluster_server": "https://kubernetes.docker.internal:6443",
-		"credential": "jkl",
-		"credential_type": "token",
-		"namespaces": [
-			"all"
-		]
-	}
-}
-```
-
-The corresponding Cluster Config JSON for the private_key authentication would be:
-```json
-{
-	"cluster_name": "docker-desktop-private-key",
-	"inventory_type": "kubernetes",
-	"cluster_config": {
-		"cluster_certificate": "abc",
-		"cluster_server": "https://kubernetes.docker.internal:6443",
-        "client_certificate": "def",
-		"credential": "ghi",
-		"credential_type": "private_key",
-		"namespaces": [
-			"all"
-		]
-	}
-}
-```
-
-### Usage
-Once a cluster is configured, Anchore will execute the kai binary on an interval, parse the JSON output, and then store the current snapshot of the inventory.
-That inventory may be listed by running HTTP GET on `/v1/enterprise/inventories`.
-
-To configure the interval on which the kai binary runs, adjust the value of the `ANCHORE_CATALOG_K8S_INVENTORY_REPORT_INTERVAL_SEC` environment variable on the enterprise catalog service. By default, it runs every 5 minutes.
-
-Clusters may be retrieved in list format via HTTP GET on `/v1/enterprise/inventories/clusters` or by name, with HTTP GET on `v1/enterprise/inventories/clusters/<name>`
-They may also be deleted via HTTP DELETE on `/v1/enterprise/inventories/clusters/<name>`. Once the cluster is removed, inventory will no longer be reported.
-
-## External Mode
-
-If you would prefer to not provide Kubernetes API access to Anchore directly, `kai` can be configured to run as an agent within your cluster via a helm chart, and can also run on it's own as a CLI tool (for more information about the CLI itself, head over to the [kai repo](https://github.com/anchore/kai).
-
-`kai`'s helm chart is hosted as part of the https://charts.anchore.io repo. It is based on the [anchore/kai](https://hub.docker.com/r/anchore/kai) docker image. 
+As an agent kai is installed using helm and the helm chart is hosted as part of the https://charts.anchore.io repo. It is based on the [anchore/kai](https://hub.docker.com/r/anchore/kai) docker image. 
 
 To install the helm chart, follow these steps:
+
+1. Configure your username, password, Anchore URL and cluster name in the [values file](https://github.com/anchore/anchore-charts/tree/master/stable/kai/values.yaml).
+
+```
+  # Path should not be changed, cluster value is used to tell Anchore which cluster this inventory is coming from
+  kubeconfig:
+    cluster: <unique-name-for-your-cluster>
+
+  anchore:
+    url: <URL for your>
+
+    # Note: reccommend using the inventory-agent role
+    user: <user>
+    password: <password>
+```
+
+2. Run helm install in the cluster(s) you wish to track 
 ```
 $ helm repo add anchore https://charts.anchore.io
 $ helm install <release> -f <values.yaml> anchore/kai
 ``` 
-An example values file can be found [here](https://github.com/anchore/anchore-charts/tree/master/stable/kai/values.yaml).
 
-The key configurations are in the `kai.anchore` section. Kai must be able to resolve the Anchore URL and requires API credentials.
+Kai must be able to resolve the Anchore URL and requires API credentials. Review the kai logs if you are not able to see the inventory results in the UI. 
 
 Note: the Anchore API Password can be provided via a kubernetes secret, or injected into the environment of the `kai` container
 * For injecting the environment variable, see: `inject_secrets_via_env`
 * For providing your own secret for the Anchore API Password, see: `kai.existing_secret`. `kai` creates it's own secret based on your values.yaml file for key `kai.anchore.password`, but the `kai.existingSecret` key allows you to create your own secret and provide it in the values file.
+
+## Agentless mode
+
+In addition to running as agent kai can also be run by Anchore Enterpise in an embedded mode. In this mode `kai` runs within the Anchore Enterprise, and needs a cluster configuration to access the Kubernetes API. This still requires cluster but allows for monitoring without the installation of additional components. See more details about setting up [embedded mode](./embedded/). 
+
+## CLI and API Inventory Collection
+In situations where you may not be able to have consitent network connection `kai` along with the inventory API can be used to collect and report inventory back to Anchore Enterprise. Inventory collection can also be used to collect other types of containers runtimes however non are officially supported at this time. 
+
+### Usage
+To quickly verify that you are tracking Kubernetes Inventory you can quickly access inventory results from the `anchorectl` with the  command `anchorectl inventory list`. The UI for the Kubernetes allows operators to visually navigate vulnerability resultes, source where vulnerabilties come from and apply their default policy to thier runtime. You'll be able to subscribe to changes for your clusters, quicky asses vulnerabilities and more.
+
+For more details about watching clusters, and reviewing policy results see the [Using Kubernetes Inventory](/docs/using/ui_usage/kubernetes/) section.
+
+
+
+
+

--- a/content/docs/overview/concepts/images/inventory/embedded/_index.md
+++ b/content/docs/overview/concepts/images/inventory/embedded/_index.md
@@ -1,0 +1,112 @@
+
+---
+title: "Embedded Mode"
+linkTitle: "Embedded Mode"
+weight: 1
+---
+
+## Agentless Inventory 
+With the proper credentials Anchore Enterprise can use 'KAI' to collect inventory details from your cluster. 
+Anchore supports storing either a Service Account token (recommended) or a client private key/certificate combination.
+
+### Generating a Service Account Token
+To generate a Service Account token for your cluster with the necessary permissions (view), follow these steps:
+1. Create a Service Account: `$ kubectl create serviceaccount <name> -n <namespace>`
+    * ex. `$ kubectl create serviceaccount anchore-runtime-inventory -n default`
+1. Bind the Service Account to a Role: `$ kubectl create clusterrolebinding <binding-name> --clusterrole=view --serviceaccount=<namespace>:<name>`
+    * ex. `$ kubectl create clusterrolebinding anchore-runtime-inventory-binding --clusterrole=view --serviceaccount=default:anchore-runtime-inventory`
+1. Get the token name: ```$ TOKENNAME=`kubectl -n <namespace> get serviceaccount/<name> -o jsonpath='{.secrets[0].name}'` ```
+    * ex. ```$ TOKENNAME=`kubectl -n default get serviceaccount/anchore-runtime-inventory -o jsonpath='{.secrets[0].name}'` ```
+1. Get the token value, which corresponds to the "credential" field below: ```$ TOKEN=`kubectl -n <namespace> get secret $TOKENNAME -o jsonpath='{.data.token}'` ```
+    * ex. ```$ TOKEN=`kubectl -n default get secret $TOKENNAME -o jsonpath='{.data.token}'` ```
+
+The endpoints for configuring the cluster within Anchore are documented under the Enterprise Swagger route, but are also demonstrated below:
+```shell script
+$ cat kai-demo-cluster.json
+{
+	"cluster_name": "docker-desktop-token",
+	"inventory_type": "kubernetes",
+	"cluster_config": {
+		"cluster_certificate": "ABC", # redacted
+		"cluster_server": "https://kubernetes.docker.internal:6443",
+		"credential": "XYZ", #redacted
+		"credential_type": "token",
+		"namespaces": [
+			"all"
+		]
+	}
+}
+$ curl -X POST -u admin:foobar -H "Content-Type: application/json" --data-binary "@kai-demo-cluster.json" "http://localhost:8228/v1/enterprise/inventories/clusters"
+```
+Some of the fields above within the `cluster_config` correspond to fields you would see in your kubeconfig:
+* **cluster_certificate:** corresponds to `clusters[0].cluster.certificate-authority-data`
+* **cluster_server:** corresponds to `clusters[0].cluster.server`
+* **credential:** corresponds to either a service account token or the private key of a user. Note: if a private key is supplied, then a **client_certificate** must also be specified. 
+    * The private key may be found at `users[0].user.client-key-data`.
+    * The token, if included in a kubeconfig, would be found at `users[0].user.token`
+* **client_certificate:** (required only for private key authentication), corresponds to `users[0].user.client-certificate-data`
+* **credential_type:** values can either be "token" or "private_key" 
+* **namespaces:** configures which namespaces anchore will pull a runtime inventory from
+
+#### Example
+
+Consider this kubeconfig, which has both a service-account-token authenticated user as well as a private_key-authenticated user:
+```
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: abc
+    server: https://kubernetes.docker.internal:6443
+  name: docker-desktop
+contexts:
+- context:
+    cluster: docker-desktop
+    user: docker-desktop
+  name: docker-desktop
+current-context: docker-desktop
+kind: Config
+preferences: {}
+users:
+- name: docker-desktop
+  user:
+    client-certificate-data: def
+    client-key-data: ghi
+- name: kai-demo
+  user:
+    token: jkl
+```
+
+The corresponding Cluster Config JSON for the Service Account Token authentication would be:
+```json
+{
+	"cluster_name": "docker-desktop-token",
+	"inventory_type": "kubernetes",
+	"cluster_config": {
+		"cluster_certificate": "abc",
+		"cluster_server": "https://kubernetes.docker.internal:6443",
+		"credential": "jkl",
+		"credential_type": "token",
+		"namespaces": [
+			"all"
+		]
+	}
+}
+```
+
+The corresponding Cluster Config JSON for the private_key authentication would be:
+```json
+{
+	"cluster_name": "docker-desktop-private-key",
+	"inventory_type": "kubernetes",
+	"cluster_config": {
+		"cluster_certificate": "abc",
+		"cluster_server": "https://kubernetes.docker.internal:6443",
+        "client_certificate": "def",
+		"credential": "ghi",
+		"credential_type": "private_key",
+		"namespaces": [
+			"all"
+		]
+	}
+}
+```

--- a/content/docs/using/ui_usage/kubernetes/_index.md
+++ b/content/docs/using/ui_usage/kubernetes/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Kubernetes Inventory"
+linkTitle: "Kubernetes Inventory"
+weight: 1
+---
+Anchore Enterprise allows you to navigate through your Kubernetes clusters to quickly and easy asses your vulnerabilites, apply policies, and take action on them. You'll need to configure your clusters for collection before being able to take advanatage of these features. See our [installation instructions to get setup](/docs/overview/concepts/images/inventory/).
+
+### Watching Clusters and Namespaces
+Users can opt to automatically scan all the images that are deployed to a specific cluster or namespace. This is helpful to monitor
+your overall security posture in your runtime and enforce policies. Before opting to subscribe to a new cluster it's important to ensure you have proper credentials saved in Anchore to pull the images from the registry. Also watching a new cluster can create a considerable queue of images to work through and impact other users of your Anchore Enterprise deployment.
+
+### Using Charts Filters
+The charts at the top of the UI provide key contextual information about your runtime. Upon landing on the page you'll see a summary of your policy evaluations and vulnerabilities for all your clusters. Drilling down into a cluster or namespace will update these charts to represent the data for the selected cluster and/or namespace. Additionally users can select to only view clusters or namespaces with the selected filters. For example selecting only high and critical vulnerabilities will only show the clusters and/or namespaces that have those vulnerabilities.
+
+### Using Views
+In addition to navigating your runtime inventory by clusters and namespaces, users can opt to view the images or vulnerabilties across. This is a great way to identify vulnerabilities across your runtime and asses thier impact.
+
+### Assesing impact
+Another important aspect of the Kubernetes Inventory UI is the ability to asses how a vulnerability in a container images impacts your environment. For every container when you see a note about it usage being seen in particular cluster and X more... you will be able to mouse over the link for a detailed list of where else that container image is being used. This is quick way to determine the "bast-radius" of a vulnerabilty. 
+
+## Data Delays
+Due to the processing required to generate the data used by the Kubernetes Inventory UI, the results displayed may not be fully up to date. The ovreall delay depends on the configuration of how often inventory data is collected, and how frequently your reporting data is refreshed. This is similar to delays present on the dashboard. 
+
+## Policy and Account Considerations 
+The Kubernetes Inventory is only availale for an Account's default policy. You may want to consider setting up an account specifically for tracking your Kubernetes Inventory and enforcing a policy. 


### PR DESCRIPTION
This PR updates the docs related to Kubernetes UI and makes Kubernetes Inventory more prominent. Includes the following changes.

* Highlights KAI on homepage
* Adds Using Kubernetes Inventory section
* Cleans up the concepts page to focus on installing kai and moves embedded mode to sub-page.

Would still like to add screenshots to the using page but submitting as is for now. 