### PR TITLE
Fix link in 3.1.0 release notes

### DIFF
--- a/content/docs/releasenotes/3.1.0/_index.md
+++ b/content/docs/releasenotes/3.1.0/_index.md
@@ -35,7 +35,7 @@ and viewing or configuring inventory scanning.
 
 ## Tech Preview Features
 
-A new vulnerability scanner based on [Grype](https://github.com/anchore/grype) is now available in tech preview. See [Vulnerability Scanner V2]{{<ref "/docs/releasenotes/3.1.0/v2_vulnerability_scanning" >}}) for more information.
+A new vulnerability scanner based on [Grype](https://github.com/anchore/grype) is now available in tech preview. See [Vulnerability Scanner V2]({{<ref "/docs/releasenotes/3.1.0/v2_vulnerability_scanning" >}}) for more information.
 This update is not configured by default and must be set by opt-in using a configuration value.
 
 ## Enterprise Service Changes


### PR DESCRIPTION
Missing parenthesis should fix the link in the release notes.

<img width="894" alt="image" src="https://user-images.githubusercontent.com/5520906/125522732-8aca837f-b4ef-4ff6-ad83-c2246a69138e.png">
