### PR TITLE
Analyzing Images - Deleting An Image is inaccurate

### DIFF
--- a/content/docs/using/cli_usage/images/_index.md
+++ b/content/docs/using/cli_usage/images/_index.md
@@ -85,7 +85,7 @@ Full Tag: docker.io/mysql:5
 
 ### Deleting An Image
 
-The `image del` command instructs Anchore Enterprise to delete the image from the repository.
+The `image del` command instructs Anchore Enterprise to delete the image analysis from the working set.
 
 #### Get The Image Digest
 


### PR DESCRIPTION
"image del" will not "delete the image from the repository" (implying deletion of the image itself), it just removes the analysis from the working set.