### PR TITLE
anchorectl configuration: note USER, PASSWORD and URL envvars

### DIFF
--- a/content/docs/installation/anchorectl/_index.md
+++ b/content/docs/installation/anchorectl/_index.md
@@ -52,7 +52,7 @@ curl -o anchorectl.zip https://anchorectl-releases.s3-us-west-2.amazonaws.com/v0
 
 ### Configuration
 AnchoreCTL can be configured via a config file at the following locations, with the following precedence:
-1. Environment Vars (i.e. ANCHORECTL_ANCHORE_USER)
+1. Environment Vars (i.e. ANCHORECTL_ANCHORE_USER, ANCHORECTL_ANCHORE_PASSWORD, ANCHORECTL_ANCHORE_URL)
 2. Config Path override (note: if this file is not found, config SHOULD fail)
 3. .anchorectl.yaml or anchorectl.yaml
 4. .anchorectl/config.yaml


### PR DESCRIPTION
previously only ANCHORECTL_ANCHORE_USER was noted, but it's not intuitively obvious that the other needed variables are ANCHORECTL_ANCHORE_PASSWORD and ANCHORECTL_ANCHORE_URL (in anchore-cli, the corresponding var is ANCHORE_CLI_PASS which is confusing).

Signed-off-by: Paul Novarese pvn@novarese.net